### PR TITLE
120+ Pet Tactics Merged + Refactoring/Cleanup

### DIFF
--- a/Prosto_Pets/MyPets.cs
+++ b/Prosto_Pets/MyPets.cs
@@ -58,7 +58,7 @@ namespace Prosto_Pets
 
         public static List<string> ButtonNames
         {
-            get { return _abilityNames;  }
+            get { return _abilityNames; }
         }
 
         public static BattlePet Pet(int index)
@@ -340,6 +340,16 @@ namespace Prosto_Pets
         public static bool enemyIsStunned()
         {
             if (debuff("Stunned") || debuff("Crystal Prison"))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        // great in combination with weak/strong checks to choose attacks
+        public static bool myPetHasAbility(string ability)
+        {
+            if(_abilityNames.Contains(ability))
             {
                 return true;
             }

--- a/Prosto_Pets/Pets/Aquatic.cs
+++ b/Prosto_Pets/Pets/Aquatic.cs
@@ -1,6 +1,6 @@
-//////////////////////-
-//// AQUATIC / WATER //
-//////////////////////-
+/////////////////////////
+// AQUATIC PET TACTICS //
+/////////////////////////
 
 using System;
 using System.Collections.Generic;
@@ -23,301 +23,666 @@ namespace Prosto_Pets
 
             List<AandC> aquatic_abilities;
 
-            //////////////////
-            //// DRAENOR //
-            //////////////////
-
-            if (petName == "Moonshell Crab" )
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Arcane Slash",      ()=> hpEnemy < 0.2 ),	        // Slot 1
-			new AandC( "Moon Tears"                                     ),	// Slot 3
-			new AandC( "Renewing Mists",    ()=> hp < 0.7 && ! buff("Renewing Mists")	),	// Slot 3
-			new AandC( "Amplify Magic",	    ()=> hp > 0.4	          ),	// Slot 2
-			new AandC( "Shell Shield",      ()=> hp < hpEnemy && ! buff("Shell Shield" )),	        // Slot 2
-			new AandC( "Arcane Slash" 			                      ),	// Slot 1
-			new AandC( "Water Jet" 		                          ),	    // Slot 1
-		};
-            else if (petName == "Zangar Crawler")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Devour", 			() => hpEnemy < 0.20 ),	// Slot 3,  if we kill the enemy with Devour, we restore health
-			new AandC( "Blood in the Water",()=> debuff("Bleeding") ),	// Slot 3
-			new AandC( "Rip",               ()=> ! debuff("Bleeding")	),	// Slot 1
-			new AandC( "Spiny Carapace" 			          ),	// Slot 2
-			new AandC( "Shell Shield",      ()=> hp < hpEnemy && ! buff("Shell Shield" )),	// Slot 2
-			new AandC( "Rip" 			                      ),	// Slot 1
-			new AandC( "Claw" 		                          ),	// Slot 1
-		};
-
-
-            
-//////////////////
-//// CROCOLISKS //
-//////////////////
-            else if (petName == "Chuck" || petName == "Muckbreath" || petName == "Snarly" || petName == "Toothy")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Devour", 			() => hpEnemy < 0.20 ),	// Slot 3,  if we kill the enemy with Devour, we restore health
-			new AandC( "Rip" 			),	// Slot 1
-			new AandC( "Consume" 		),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 2
-			new AandC( "Water Jet" 		),	// Slot 2
-			new AandC( "Blood in the Water" )	// Slot 3
-		};
-
-            ////////////////-
-            // CRUSTACEANS //
-            ////////////////-
-            else if (petName == "Emperor Crab" || petName == "Shore Crab" || petName == "Shore Crawler" || petName == "Spirebound Crab" || petName == "Strand Crab" || petName == "Strand Crawler")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Surge",             () => hpEnemy < hp	),  	    // Slot 1  -- makes it more aggressive
-			new AandC( "Renewing Mists",    () => buffLeft("Renewing Mists") < 2	),  	// Slot 2
-			new AandC( "Healing Wave", 	    () => hp < 0.7 ),	                        // Slot 2
-			new AandC( "Shell Shield", 	    () => buffLeft("Shell Shield") < 2 ),	    // Slot 3
-			new AandC( "Snap" 			),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Whirlpool" 		)	// Slot 3
-		};
-            else if (petName == "Magical Crawdad")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Shell Shield",  () => ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Snap" 			),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Renewing Mists" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 3
-			new AandC( "Wish" 			)	// Slot 3
-		};  
-            //////////
-            // FISH //
-            //////////
-            else if (petName == "Fishy" || petName == "Tiny Goldfish")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// Slot 2
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Surge"			),	// Slot 1
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 3
-			new AandC( "Pump" 			)	// Slot 3
-		};
-            else if (petName == "Purple Puffer")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// Slot 2
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Spiked Skin" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 3
-			new AandC( "Pump" 			)	// Slot 3
-		};
-            else if (petName == "Tiny Blue Carp")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Psychic Blast" 	),	// Slot 1
-			new AandC( "Healing Stream" 	),	// Slot 2
-			new AandC( "Wild Magic" 		),	// Slot 2
-			new AandC( "Pump" 			),	// Slot 3
-			new AandC( "Mana Surge" 		)	// Slot 3
-		};
-            else if (petName == "Tiny Green Carp")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Healing Stream" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 3
-			new AandC( "Invisibility" 	)	// Slot 3
-		};
-            else if (petName == "Tiny Red Carp")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Poison Spit" 	),	// Slot 1
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Healing Stream" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 3
-			new AandC( "Spiked Skin" 	),	// Slot 3
-		};
-            else if (petName == "Tiny White Carp")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// Slot 2
-			new AandC( "Dive" 			),	// Slot 3
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Healing Stream" 	),	// Slot 3
-		};
-            ////////////////////-
-            // FROGS AND TOADS //
-            ////////////////////-
-            else if (petName == "Biletoad" || petName == "Frog" || petName == "Garden Frog" || petName == "Huge Toad" || petName == "Jubling" || petName == "Jungle Darter" || petName == "Leopard Tree Frog" || petName == "Mac Frog" || petName == "Mojo" || petName == "Small Frog" || petName == "Spotted Bell Frog" || petName == "Tree Toad" || petName == "Wood Frog" || petName == "Yellow-Bellied Bullfrog" || petName == "Toad" || petName == "Tree Frog")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// 
-			new AandC( "Water Jet" 		),	// 
-			new AandC( "Tongue Lash" 	),	// 
-			new AandC( "Cleansing Rain" 	),	// 
-			new AandC( "Frog Kiss" 		),	// 
-			new AandC( "Swarm of Flies" 	)	// 
-		};
-            else if (petName == "Swamp Croaker")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Bubble", 			() => hp < 0.7 ),	// 
-			new AandC( "Water Jet" 		),	// 
-			new AandC( "Tongue Lash" 	),	// 
-			new AandC( "Frog Kiss" 		),	// 
-			new AandC( "Swarm of Flies" 	),	// 
-			new AandC( "Croak" 			)	// 
-		};
-            ////////////-
-            // INSECTS //
-            ////////////-
-            else if (petName == "Aqua Strider" || petName == "Dancing Water Skimmer" || petName == "Eternal Strider" || petName == "Mirror Strider")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	 () => hp < 0.7 ),	// Slot 2
-			new AandC( "Cleansing Rain", () =>	hp < 0.9 ),	// Slot 2
-			new AandC( "Water Jet" 		                          ),    // Slot 1
-			new AandC( "Poison Spit",	 () =>	buff("Pumped Up")),	// Slot 1
-			new AandC( "Soothe" 	                                    ),  // Slot 3
-			new AandC( "Pump",      	 () => ! buff("Pumped Up") ),  // Slot 3
-		};
-            ////////////-
-            // MAMMALS //
-            ////////////-
-            else if (petName == "Golden Civet" || petName == "Golden Civet Kitten" || petName == "Kuitan Mongoose" || petName == "Mongoose" || petName == "Mongoose Pup" || petName == "Sifang Otter" || petName == "Sifang Otter Pup")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Survival", 		() => hp < 0.3 ),	// Slot 2
-			new AandC( "Dive" 			),	// Slot 3
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Gnaw" 			),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 2
-			new AandC( "Surge" 			),	// Slot 3
-		};
-            //////////////
-            // PENGUINS //
-            //////////////
-            else if (petName == "Mr. Chilly" || petName == "Pengu" || petName == "Tundra Penguin")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Frost Spit" 		),	// Slot 2
-			new AandC( "Slippery Ice" 	),	// Slot 2
-			new AandC( "Ice Lance" 		),	// Slot 3
-			new AandC( "Belly Slide" 	)	// Slot 3
-		};
-            ////////////-
-            // TURTLES //
-            ////////////-
-            else if (petName == "Darkmoon Turtle" || petName == "Softshell Snapling" || petName == "Speedy" || petName == "Spiny Terrapin" || petName == "Turquoise Turtle")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// Slot 2
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Shell Shield",  () => ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Grasp" 			),	// Slot 1
-			new AandC( "Powerball" 		)	// Slot 3
-		};
-            else if (petName == "Emerald Turtle")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// Slot 2
-			new AandC( "Shell Shield",  () => ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Emerald Bite" 	),	// Slot 1
-			new AandC( "Grasp" 			),	// Slot 1
-			new AandC( "Powerball" 		),	// Slot 3
-		};
-            else if (petName == "Wanderer's Festival Hatchling")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Shell Shield",  () => ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Grasp" 			),	// Slot 1
-			new AandC( "Perk Up" 		),	// Slot 2
-			new AandC( "Pump" 			),	// Slot 3
-			new AandC( "Cleansing Rain" 	)	// Slot 3
-		};
-            //////////////////-
-            // MISCELLANEOUS //
-            //////////////////-
-            else if (petName == "Horny Toad")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Healing Wave", 	() => hp < 0.7 ),	// Slot 2
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Tongue Lash" 	),	// Slot 1
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Frog Kiss" 		),	// Slot 3
-			new AandC( "Swarm of Flies" 	)	// Slot 3
-		};
-            else if (petName == "Sea Pony")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Tidal Wave" 		),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 2
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 3
-			new AandC( "Pump" 			)	// Slot 3
-		};
-            else if (petName == "Spawn of G'nathus")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Dive" 			),	// Slot 2
-			new AandC( "Swallow You Whole"),	// Slot 1
-			new AandC( "Jolt" 			),	// Slot 1
-			new AandC( "Lightning Shield"),	// Slot 2
-			new AandC( "Thunderbolt" 	),	// Slot 3
-			new AandC( "Paralyzing Shock")	// Slot 3
-		};
-            else if (petName == "Gahz'rooki")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Devour", 		() => 	hpEnemy < 0.20 ),	// Slot 2,  if we kill the enemy with Devour, we restore health
-			new AandC( "Bite"               ),	// Slot 1
-			new AandC( "Tail Slap"   		),	// Slot 1
-			new AandC( "Swallow You Whole"  ),	// Slot 2
-			new AandC( "Whirlpool"   		),	// Slot 3
-			new AandC( "Geyser"   )         	// Slot 3
-		};
-            else if (petName == "Tideskipper")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Crush"          ),	// Slot 1
-			new AandC( "Grasp" 			),	// Slot 1
-			new AandC( "Tidal Wave" 	),	// Slot 2
-			new AandC( "Body Slam"		),	// Slot 2
-			new AandC( "Clobber" 		),	// Slot 3
-			new AandC( "Geyser"         ),	// Slot 3
-		};
-            else if (petName == "Hydraling")
-                aquatic_abilities = new List<AandC>()
-		{
-			new AandC( "Swallow You Whole", ()=> hpEnemy<0.25 ),	// Slot 2
-			new AandC( "Call Lightning", ()=> !weather("Lightning Storm")		),	// Slot 2  TODO: not always beneficial, only if mech's on our side
-			new AandC( "Shell Armor" 	),	// Slot 3
-			new AandC( "Whirlpool"         ),	// Slot 3
-			new AandC( "Deep Byte"          ),	// Slot 1
-			new AandC( "Tail Slap"		),	// Slot 1
-		};
-
-            //////////////////-
-            else // Unknown aquatic
+            switch (petName)
             {
-                Logger.Alert("Unknown aquatic pet: " + petName);
-                return null;
+                case "Aqua Strider":
+                case "Dancing Water Skimmer":
+                case "Eternal Strider":
+                case "Mirror Strider":
+                    /* Abilities:
+                     * Slot 1: Water Jet    | Poison Spit
+                     * Slot 2: Healing Wave | Cleansing Rain
+                     * Slot 3: Soothe       | Pump
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave", 	 () => hp < 0.7 ),	
+			            new AandC( "Cleansing Rain", () => hp < 0.9 ),	
+			            new AandC( "Water Jet"), 
+			            new AandC( "Poison Spit",	 () =>	buff("Pumped Up")),	
+			            new AandC( "Soothe"),
+			            new AandC( "Pump",      	 () => ! buff("Pumped Up") ),  
+		            };
+                    break;
+
+                case "Biletoad":
+                case "Frog": 
+                case "Garden Frog": 
+                case "Huge Toad": 
+                case "Jubling": 
+                case "Jungle Darter": 
+                case "Leopard Tree Frog": 
+                case "Mac Frog": 
+                case "Mojo": 
+                case "Small Frog": 
+                case "Spotted Bell Frog": 
+                case "Toad": 
+                case "Tree Frog":
+                case "Wood Frog":
+                case "Yellow-Bellied Bullfrog":
+                    /* Abilities:
+                     * Slot 1: Water Jet    | Tongue Lash
+                     * Slot 2: Healing Wave | Cleansing Rain
+                     * Slot 3: Frog Kiss    | Swarm of Flies
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave", 	    () => hp < 0.7 ),
+			            new AandC( "Water Jet"),
+			            new AandC( "Tongue Lash"),	 
+			            new AandC( "Cleansing Rain"),
+			            new AandC( "Frog Kiss"),	
+			            new AandC( "Swarm of Flies")
+		            };
+                    break;
+
+                case "Chuck":
+                case "Muckbreath":
+                case "Snarly":
+                case "Toothy":
+                    /* Abilities:
+                     * Slot 1: Rip      | Consume
+                     * Slot 2: Surge    | Water Jet
+                     * Slot 3: Devour   | Blood in the Water
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Devour",             () => hpEnemy < 0.20 ),	
+			            new AandC( "Rip"),	
+			            new AandC( "Consume"),
+			            new AandC( "Surge"),
+			            new AandC( "Water Jet"),	
+			            new AandC( "Blood in the Water")
+		            };
+                    break;
+
+                case "Darkmoon Turtle":
+                case "Softshell Snapling":
+                case "Speedy":
+                case "Spiny Terrapin":
+                case "Turquoise Turtle":
+                    /* Abilities:
+                     * Slot 1: Bite         | Grasp
+                     * Slot 2: Shell Shield | Healing Wave
+                     * Slot 3: Headbutt     | Powerball
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave",  () => hp < 0.7 ),
+			            new AandC( "Headbutt"),
+			            new AandC( "Shell Shield",  () => ! buff("Shell Shield") ),
+			            new AandC( "Bite"),
+			            new AandC( "Grasp"),
+			            new AandC( "Powerball")
+		            };
+                    break;
+
+                case "Emerald Turtle":
+                    /* Abilities:
+                     * Slot 1: Emerald Bite | Grasp
+                     * Slot 2: Shell Shield | Healing Wave
+                     * Slot 3: Headbutt     | Powerball
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave", 	() => hp < 0.7 ),
+			            new AandC( "Shell Shield",  () => ! buff("Shell Shield") ),
+			            new AandC( "Headbutt"),
+			            new AandC( "Emerald Bite"),
+			            new AandC( "Grasp"),
+			            new AandC( "Powerball"),
+		            };
+                    break;
+
+                case "Emperor Crab":
+                case "Shore Crab":
+                case "Shore Crawler":
+                case "Spirebound Crab":
+                case "Strand Crab":
+                case "Strand Crawler":
+                    /* Abilities:
+                     * Slot 1: Snap             | Surge
+                     * Slot 2: Renewing Mists   | Healing Wave
+                     * Slot 3: Shell Shield     | Whirlpool
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Surge",             () => hpEnemy < hp	),
+			            new AandC( "Renewing Mists",    () => buffLeft("Renewing Mists") < 2	),
+			            new AandC( "Healing Wave", 	    () => hp < 0.7 ),
+			            new AandC( "Shell Shield", 	    () => buffLeft("Shell Shield") < 2 ),
+			            new AandC( "Snap"),
+			            new AandC( "Surge"),
+			            new AandC( "Whirlpool")
+		            };
+                    break;
+
+                case "Fishy":
+                case "Tiny Goldfish":
+                    /* Abilities:
+                     * Slot 1: Water Jet        | Surge
+                     * Slot 2: Cleansing Rain   | Healing Wave
+                     * Slot 3: Whirlpool        | Pump
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave", 	    () => hp < 0.7 ),
+			            new AandC( "Water Jet"),
+			            new AandC( "Surge"),
+			            new AandC( "Cleansing Rain"),
+			            new AandC( "Whirlpool"),
+			            new AandC( "Pump")
+		            };
+                    break;
+
+                case "Frostshell Pincher": 
+                case "Ironclaw Scuttler": 
+                case "Kelp Scuttler":
+                    /* Changelog:
+                     * 2015-01-20: Dive is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Rip              | Claw
+                     * Slot 2: Spiny Carapace   | Shell Shield
+                     * Slot 3: Dive             | Blood in the Water
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Dive",               () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Rip",                () => ! debuff("Bleeding")),
+                        new AandC("Spiny Carapace",     () => ! buff("Spiny Carapace")),
+                        new AandC("Shell Shield",       () => ! buff("Shell Shield")),
+                        new AandC("Blood in the Water", () => debuff("Bleeding")),
+                        new AandC("Rip"),
+                        new AandC("Claw"),
+                    };
+                    break;
+
+                case "Gahz'rooki":
+                    /* Abilities:
+                     * Slot 1: Bite         | Tail Slap
+                     * Slot 2: Devour       | Swallow You Whole
+                     * Slot 3: Whirlpool    | Geyser
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Devour", 		    () => 	hpEnemy < 0.20 ),
+			            new AandC("Bite"),
+			            new AandC("Tail Slap"),
+			            new AandC("Swallow You Whole"),
+			            new AandC("Whirlpool"),
+			            new AandC("Geyser"),
+		            };
+                    break;
+
+                case "Golden Civet": 
+                case "Golden Civet Kitten": 
+                case "Kuitan Mongoose": 
+                case "Mongoose": 
+                case "Mongoose Pup": 
+                case "Sifang Otter": 
+                case "Sifang Otter Pup":
+                    /* Abilities:
+                     * Slot 1: Bite     | Gnaw
+                     * Slot 2: Screech  | Survival
+                     * Slot 3: Surge    | Dive
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Survival", () => hp < 0.3 ),
+			            new AandC( "Dive"),
+			            new AandC( "Bite"),
+			            new AandC( "Gnaw"),
+			            new AandC( "Screech"),
+			            new AandC( "Surge"),
+		            };
+                    break;
+
+                case "Gulp Froglet":
+                    /* Changelog:
+                     * 2015-01-20: Toxic Skin is now only used if it is not already active - Studio60
+                     * 2015-01-19: Mudslide is no longer used if it is already active - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Water Jet    | Frog Kiss
+                     * Slot 2: Mudslide     | Toxic Skin
+                     * Slot 3: Swarm        | Corpse Explosion
+                     *
+                     * TODO: Corpse Explosion should only be used if other friendly pets are alive
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Mudslide",           () => ! weather("Mudslide")),
+                        new AandC("Toxic Skin",         () => ! buff("Toxic Skin")),
+                        new AandC("Swarm",              () => ! debuff("Shattered Defenses")),
+                        new AandC("Water Jet"),
+                        new AandC("Frog Kiss"),
+                        new AandC("Corpse Explosion"),
+                    };
+                    break;
+
+                case "Hydraling":
+                    /* Abilities:
+                     * Slot 1: Deep Bite        | Tail Slap
+                     * Slot 2: Call Lightning   | Swallow You Whole
+                     * Slot 3: Shell Armor      | Whirlpool
+                     *
+                     * TODO: Call Lightning is not always beneficial, only if mech's on our side
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Swallow You Whole", () => hpEnemy < 0.25 ),
+			            new AandC( "Call Lightning",    () => ! weather("Lightning Storm")),
+			            new AandC( "Shell Armor"),
+			            new AandC( "Whirlpool"),
+			            new AandC( "Deep Byte"),
+			            new AandC( "Tail Slap"),
+		            };
+                    break;
+
+                case "Horny Toad":
+                    /* Abilities:
+                     * Slot 1: Water Jet    | Tongue Lash
+                     * Slot 2: Healing Wave | Cleansing Rain
+                     * Slot 3: Frog Kiss    | Swarm of Flies
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave",      () => hp < 0.7 ),
+			            new AandC( "Water Jet"),
+			            new AandC( "Tongue Lash"),
+			            new AandC( "Cleansing Rain"),
+			            new AandC( "Frog Kiss"),
+			            new AandC( "Swarm of Flies"),
+		            };
+                    break;
+
+                case "Land Shark":
+                    /* Changelog:
+                     * 2015-01-20: Blood in the Water is now checking for all bleed effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Water Jet            | Tail Slap
+                     * Slot 2: Tidal Wave           | Focus
+                     * Slot 3: Blood in the Water   | Swallow You Whole
+                     *
+                     * TODO: Tidal Wave should check for enemy/own objects
+                     * TODO: Blood in the Water should check if team pets have bleed abilities
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Swallow You Whole",  () => hpEnemy < 0.25),
+                        new AandC("Tidal Wave",         () => debuff("Decoy") || debuff("Turret")),
+                        new AandC("Focus",              () => ! buff("Focused")),
+                        new AandC("Blood in the Water", () => enemyIsBleeding()),
+                        new AandC("Water Jet"),
+                        new AandC("Tail Slap"),
+                    };
+                    break;
+
+                case "Leviathan Hatchling":
+                    /* Changes:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1 
+                     *
+                     * Abilities:
+                     * Slot 1: Tail Slap    | Water Jet
+                     * Slot 2: Toxic Skin   | Poison Spit
+                     * Slot 3: Whirlpool    | Primal Cry
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Toxic Skin", () => ! buff("Toxic Skin")),	// Slot 2
+                        new AandC("Poison Spit", () => ! debuff("Poisoned")),	// Slot 2
+                        new AandC("Whirlpool", () => hpEnemy > 0.4),	// Slot 3
+                        new AandC("Primal Cry", () => ! debuff("Speed Reduction")),	// Slot 3
+                        new AandC("Tail Slap"),	// Slot 1
+                        new AandC("Water Jet"),	// Slot 1
+                    };
+                    break;
+
+                case "Magical Crawdad":
+                    /* Abilities: 
+                     * Slot 1: Snap             | Surge
+                     * Slot 2: Renewing Mists   | Shell Shield
+                     * Slot 3: Whirlpool        | Wish
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Shell Shield",      () => ! buff("Shell Shield")),
+			            new AandC( "Snap"),
+			            new AandC( "Surge"),
+			            new AandC( "Renewing Mists"),
+			            new AandC( "Whirlpool"),
+			            new AandC( "Wish")
+		            };
+                    break;
+
+                case "Moonshell Crab":
+                    /* Abilities:
+                     * Slot 1: Arcane Slash     | Water Jet
+                     * Slot 2: Shell Shield     | Amplify Magic
+                     * Slot 3: Renewing Mists   | Moon Tears
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Arcane Slash",      () => hpEnemy < 0.2 ),
+			            new AandC( "Moon Tears"),
+			            new AandC( "Renewing Mists",    () => hp < 0.7 && ! buff("Renewing Mists")	),
+			            new AandC( "Amplify Magic",	    () => hp > 0.4),
+			            new AandC( "Shell Shield",      () => hp < hpEnemy && ! buff("Shell Shield" )),
+			            new AandC( "Arcane Slash"),
+			            new AandC( "Water Jet"),
+		            };
+                    break;
+
+                case "Mr. Chilly":
+                case "Pengu": 
+                case "Tundra Penguin":
+                    /* Abilities:
+                     * Slot 1: Peck         | Surge
+                     * Slot 2: Frost Spit   | Slippery Ice
+                     * Slot 3: Ice Lance    | Belly Slide
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Peck"),
+			            new AandC("Surge"),
+			            new AandC("Frost Spit"),
+			            new AandC("Slippery Ice"),
+			            new AandC("Ice Lance"),
+			            new AandC("Belly Slide"),
+		            };
+                    break;
+
+                case "Mud Jumper":
+                    /* Changelog:
+                     * 2015-01-20: Bubble is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-19: Mudslide is no longer used if it is already active
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Water Jet    | Tongue Lash
+                     * Slot 2: Mudslide     | Swarm of Flies
+                     * Slot 3: Bubble       | Pump
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Bubble",         () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Pump",           () => buff("Pumped Up")),
+                        new AandC("Mudslide",       () => ! weather("Mudslide")),
+                        new AandC("Swarm of Flies", () => ! debuff("Swarm of Flies")),
+                        new AandC("Pump",           () => hpEnemy > 0.4),
+                        new AandC("Water Jet"),
+                        new AandC("Tongue Lash"),
+                    };
+                    break;
+
+                case "Puddle Terror":
+                    /* Changelog:
+                     * 2015-01-20: Dive is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Clobber is now checking for all stun effects - Studio60
+                     * 2015-01-19: Clobber is only used if the enemy is not Resilient - Studio60
+                     * 2015-01-19: Nature's Ward conditions have been changed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities: 
+                     * Slot 1: Water Jet        | Punch
+                     * Slot 2: Nature's Ward    | Clobber
+                     * Slot 3: Sunlight         | Dive
+                     *
+                     * Tactic Information:
+                     * Nature's Ward is not used against aquatic enemies due to type disadvantage
+                    */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Dive",           () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Sunlight",       () => ! weather("Sunny Day")),
+                        new AandC("Nature's Ward",  () => hp < 0.9 && ! famEnemy(PF.Aquatic) && ! buff("Nature's Ward")),
+                        new AandC("Clobber",        () => ! enemyIsResilient()),
+                        new AandC("Water Jet"),
+                        new AandC("Punch"),
+                    };
+                    break;
+
+                case "Purple Puffer":
+                    /* Abilities: 
+                     * Slot 1: Water Jet    | Surge
+                     * Slot 2: Spiked Skin  | Healing Wave
+                     * Slot 3: Whirlpool    | Pump
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC( "Healing Wave",  () => hp < 0.7 ),
+			            new AandC( "Water Jet"),
+			            new AandC( "Surge"),
+			            new AandC( "Spiked Skin"),
+			            new AandC( "Whirlpool"),
+			            new AandC( "Pump"),
+		            };
+                    break;
+
+                case "Sea Calf":
+                    /* Changelog:
+                     * 2015-01-20: Bubble is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Dive is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Blood in the Water is now checking for all bleed effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities: 
+                     * Slot 1: Water Jet    | Surge
+                     * Slot 2: Bubble       | Dive
+                     * Slot 3: Feed         | Blood in the Water
+                     *
+                     * TODO: Blood in the Water should check if team pets have bleed abilities
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Bubble",             () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Dive",               () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Feed",               () => hp < 0.7),
+                        new AandC("Blood in the Water", () => enemyIsBleeding()),
+                        new AandC("Water Jet"),
+                        new AandC("Surge"),
+                    };
+                    break;
+
+                case "Sea Pony":
+                    /* Abilities: 
+                     * Slot 1: Water Jet    | Tidal Wave
+                     * Slot 2: Surge        | Cleansing Rain
+                     * Slot 3: Whirlpool    | Pump
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Water Jet"),
+			            new AandC("Tidal Wave"),
+			            new AandC("Surge"),
+			            new AandC("Cleansing Rain"),
+			            new AandC("Whirlpool"),
+			            new AandC("Pump"),
+		            };
+                    break;
+
+                case "Spawn of G'nathus":
+                    /* Abilities:
+                     * Slot 1: Swallow You Whole    | Jolt
+                     * Slot 2: Dive                 | Lightning Shield
+                     * Slot 3: Thunderbolt          | Paralyzing Shock
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Dive"),
+			            new AandC("Swallow You Whole"),
+			            new AandC("Jolt"),
+			            new AandC("Lightning Shield"),
+			            new AandC("Thunderbolt"),
+			            new AandC("Paralyzing Shock"),
+		            };
+                    break;
+
+                case "Spineclaw Crab":
+                    /* Changelog:
+                     * 2015-01-20: Blood in the Water is now checking for all bleed effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Rip              | Triple Snap
+                     * Slot 2: Spiny Carapace   | Healing Wave
+                     * Slot 3: Whirlpool        | Blood in the Water
+                     */
+                    aquatic_abilities = new List<AandC>() {
+                        new AandC("Rip",                () => ! debuff("Bleeding")),
+                        new AandC("Spiny Carapace",     () => ! buff("Spiny Carapace")),
+                        new AandC("Healing Wave",       () => hp < 0.6),
+                        new AandC("Whirlpool",          () => hpEnemy > 0.5),
+                        new AandC("Blood in the Water", () => enemyIsBleeding()),
+                        new AandC("Rip"),
+                        new AandC("Triple Snap"),
+                    };
+                    break;
+
+                case "Swamp Croaker":
+                    /* Abilities:
+                     * Slot 1: Water Jet    | Tongue Lash
+                     * Slot 2: Croak        | Swarm of Flies
+                     * Slot 3: Frog Kiss    | Bubble
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Bubble",         () => hp < 0.7 ),
+			            new AandC("Water Jet"),
+			            new AandC("Tongue Lash"),
+			            new AandC("Frog Kiss"),
+			            new AandC("Swarm of Flies"),
+			            new AandC("Croak"),
+		            };
+                    break;
+
+                case "Tideskipper":
+                    /* Abilities:
+                     * Slot 1: Crush        | Grasp
+                     * Slot 2: Tidal Wave   | Body Slam
+                     * Slot 3: Clobber      | Geyser
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Crush"),
+			            new AandC("Grasp"),
+			            new AandC("Tidal Wave"),
+			            new AandC("Body Slam"),
+			            new AandC("Clobber"),
+			            new AandC("Geyser"),
+		            };
+                    break;
+
+                case "Tiny Blue Carp":
+                    /* Abilities: 
+                     * Slot 1: Surge            | Psychic Blast
+                     * Slot 2: Healing Stream   | Wild Magic
+                     * Slot 3: Pump             | Mana Surge
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Surge"),
+			            new AandC("Psychic Blast"),
+			            new AandC("Healing Stream"),
+			            new AandC("Wild Magic"),
+			            new AandC("Pump"),
+			            new AandC("Mana Surge"),
+		            };
+                    break;
+
+                case "Tiny Green Carp":
+                    /* Abilities:
+                     * Slot 1: Water Jet        | Surge
+                     * Slot 2: Cleansing Rain   | Healing Stream
+                     * Slot 3: Whirlpool        | Invisibility
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Water Jet"),
+			            new AandC("Surge"),
+			            new AandC("Cleansing Rain"),
+			            new AandC("Healing Stream"),
+			            new AandC("Whirlpool"),
+			            new AandC("Invisibility"),
+		            };
+                    break;
+
+                case "Tiny Red Carp":
+                    /* Abilities:
+                     * Slot 1: Water Jet        | Poison Spit
+                     * Slot 2: Cleansing Rain   | Healing Stream
+                     * Slot 3: Whirlpool        | Spiked Skin
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Water Jet"),
+			            new AandC("Poison Spit"),
+			            new AandC("Cleansing Rain"),
+			            new AandC("Healing Stream"),
+			            new AandC("Whirlpool"),
+			            new AandC("Spiked Skin"),
+		            };
+                    break;
+
+                case "Tiny White Carp":
+                    /* Abilities:
+                     * Slot 1: Water Jet        | Surge
+                     * Slot 2: Cleansing Rain   | Healing Wave
+                     * Slot 3: Dive             | Healing Stream
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Healing Wave",   () => hp < 0.7 ),
+			            new AandC("Dive"),
+			            new AandC("Water Jet"),
+			            new AandC("Surge"),
+			            new AandC("Cleansing Rain"),
+			            new AandC("Healing Stream"),
+		            };
+                    break;
+
+                case "Wanderer's Festival Hatchling":
+                    /* Abilities: 
+                     * Slot 1: Bite         | Grasp
+                     * Slot 2: Shell Shield | Perk Up
+                     * Slot 3: Pump         | Cleansing Rain
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Shell Shield",   () => ! buff("Shell Shield")),
+			            new AandC("Bite"),
+			            new AandC("Grasp"),
+			            new AandC("Perk Up"),
+			            new AandC("Pump"),
+			            new AandC("Cleansing Rain"),
+		            };
+                    break;
+
+                case "Zangar Crawler":
+                    /* Abilities: 
+                     * Slot 1: Rip              | Claw
+                     * Slot 2: Spiny Carapace   | Shell Shield
+                     * Slot 3: Dive             | Blood in the Water
+                     */
+                    aquatic_abilities = new List<AandC>()
+		            {
+			            new AandC("Devour", 			() => hpEnemy < 0.20 ),
+			            new AandC("Blood in the Water", () => debuff("Bleeding")),
+			            new AandC("Rip",                () => ! debuff("Bleeding")),
+			            new AandC("Spiny Carapace"),
+			            new AandC("Shell Shield",       () => hp < hpEnemy && ! buff("Shell Shield" )),
+			            new AandC("Rip"),
+			            new AandC("Claw"),
+		            };
+                    break;
+
+                default:
+                    /////////////////////////
+                    // Unknown Aquatic Pet //
+                    /////////////////////////
+                    Logger.Alert("Unknown aquatic pet: " + petName);
+                    aquatic_abilities = null;
+                    break;
             }
+
             return aquatic_abilities;
         }
     }

--- a/Prosto_Pets/Pets/Beast.cs
+++ b/Prosto_Pets/Pets/Beast.cs
@@ -1,6 +1,6 @@
-////////////////
-// BEAST //
-////////////////  
+///////////////////////
+// BEAST PET TACTICS //
+///////////////////////
 
 using System;
 using System.Collections.Generic;
@@ -24,534 +24,1089 @@ namespace Prosto_Pets
 
             List<AandC> beast_abilities;
 
-            /////////////-
-            // DRAENOR //
-            /////////////-
-            if (petName == "Mossbite Skitterer")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Gnaw",       ()=> speed > speedEnemy ),	// Slot 1
-			new AandC("Ravage", 	() => hpEnemy < 0.2	),	// Slot 2
-			new AandC("Puncture Wound", ()=> debuff("Poisoned") 	),	// Slot 3
-			new AandC("Takedown",   ()=> debuff("Stunned") 			),	// Slot 1
-			new AandC("Body Slam" 		),	// Slot 3
-			new AandC("Gnaw" 			),	// Slot 1
-			new AandC("Bite" 			),	// Slot 1
-		};
-            //////////-
-// BEARS //
-//////////-
-            else if (petName == "Baby Blizzard Bear" || petName == "Poley")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Roar" 			),	// Slot 1
-			new AandC("Bash" 			),	// Slot 2
-			new AandC("Hibernate" 		),	// Slot 2
-			new AandC("Maul" 			),	// Slot 3
-			new AandC("Call Blizzard" 	)	// Slot 3
-		};
-            else if (petName == "Darkshore Cub" || petName == "Dun Morogh Cub" || petName == "Hyjal Bear Cub" || petName == "Panda Cub")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Roar" 			),	// Slot 1
-			new AandC("Hibernate" 		),	// Slot 2
-			new AandC("Bash" 			),	// Slot 2
-			new AandC("Maul" 			),	// Slot 3
-			new AandC("Rampage" 		)	// Slot 3
-		};
-            ////////////
-            // CANINES //
-            ////////////
-            else if (petName == "Alpine Foxling" || petName == "Alpine Foxling Kit" || petName == "Arctic Fox Kit" || petName == "Fjord Worg Pup" || petName == "Fox Kit" || petName == "Worg Pup")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Dazzling Dance", () =>	speed < speedEnemy && ! buff("Dazzling Dance") ),	// Slot 3
-			new AandC("Leap", 			() =>   speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Flurry" 			),	// Slot 1
-			new AandC("Crouch" 			),	// Slot 2
-			new AandC("Howl" 			)	// Slot 2
-		};
-            else if (petName == "Tito")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Cyclone",	() =>		 ! debuff("Cyclone") ),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Triple Snap" 	),	// Slot 1
-			new AandC("Impale"			),	// Slot 2
-			new AandC("Howl" 			),	// Slot 2
-			new AandC("Buried Treasure" ),	// Slot 3
-		};
-            else if (petName == "Moon Moon")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Moon Fang"		),	// Slot 1
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Howl" 			),	// Slot 2
-			new AandC("Crouch"			),	// Slot 2
-			new AandC("Moon Tears" 		),	// Slot 3
-			new AandC("Moon Dance" 		),	// Slot 3
-		};
-            //////////////-
-            // DIREHORNS //
-            //////////////-
-            else if (petName == "Direhorn Runt" || petName == "Pygmy Direhorn" || petName == "Stunted Direhorn")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Trihorn Charge" 	),	// Slot 1
-			new AandC("Trample" 		),	// Slot 1
-			new AandC("Horn Attack" 	),	// Slot 2
-			new AandC("Stampede" 		),	// Slot 2
-			new AandC("Primal Cry" 		),	// Slot 3
-			new AandC("Trihorn Shield" 	),	// Slot 3
-		};
-            ////////////-
-            // FELINES //
-            ////////////-
-            else if (petName == "Black Tabby Cat" || petName == "Bombay Cat" || petName == "Calico Cat" || petName == "Cat" || petName == "Cheetah Cub" || petName == "Cornish Rex Cat" || petName == "Darkmoon Cub" || petName == "Nightsaber Cub" || petName == "Orange Tabby Cat" || petName == "Panther Cub" || petName == "Sand Kitten" || petName == "Siamese Cat" || petName == "Silver Tabby Cat" || petName == "Snow Cub" || petName == "White Kitten" || petName == "Winterspring Cub")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Devour", () =>			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC("Claw" 			),	// Slot 1
-			new AandC("Pounce" 			),	// Slot 1
-			new AandC("Rake" 			),	// Slot 2
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Prowl" 			),	// Slot 3
-		};
-            else if (petName == "Feline Familiar")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Devour", () =>			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC("Onyx Bite" 		),	// Slot 1
-			new AandC("Pounce" 			),	// Slot 1
-			new AandC("Stoneskin" 		),	// Slot 2
-			new AandC("Call Darkness" 	),	// Slot 2
-			new AandC("Prowl" 			),	// Slot 3
-		};
-            else if (petName == "Xu-Fu, Cub of Xuen")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Spirit Claws" 	),	// Slot 1
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Feed" 			),	// Slot 2
-			new AandC("Moonfire" 		),	// Slot 2
-			new AandC("Vengeance" 		),	// Slot 3
-			new AandC("Prowl" 			),	// Slot 3
-		};
-            ////////////-
-            // INSECTS //
-            ////////////-
-            else if (petName == "Devouring Maggot" || petName == "Festering Maggot" || petName == "Jungle Grub" || petName == "Larva" || petName == "Maggot" || petName == "Mr. Grubbs")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Leap", 	() =>		 ! buff("Speed Boost") && (speed < speedEnemy) ),	// Slot 3
-			new AandC("Acidic Goo", () =>		 ! debuff("Acidic Goo") ),	// Slot 2
-			new AandC("Chomp" 			),	// Slot 1
-			new AandC("Consume" 		),	// Slot 1
-			new AandC("Sticky Goo" 		),	// Slot 2
-			new AandC("Burrow" 			),	// Slot 3
-		};
-            else if (petName == "Silithid Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 2
-			new AandC("Devour", 	() =>		hpEnemy < 0.20 ),	// Slot 1,  if( we kill the enemy with Devour, we restore health
-			new AandC("Scratch" 		),	// Slot 1
-			new AandC("Hiss" 			),	// Slot 2
-			new AandC("Swarm" 			),	// Slot 3
-			new AandC("Sandstorm" 		),	// Slot 3
-		};
-            else if (petName == "Kovok")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Poison Fang" 	),	// Slot 1
-			new AandC("Body Slam" 		),	// Slot 1
-			new AandC("Pheromones" 		),	// Slot 2
-			new AandC("Digest Brains" 	),	// Slot 2
-			new AandC("Black Claw" 		),	// Slot 3
-			new AandC("Puncture Wound" 	),	// Slot 3
-		};
-            ////////////-
-            // LIZARDS //
-            ////////////-
-            else if (petName == "Ash Lizard" || petName == "Diemetradon Hatchling" || petName == "Horned Lizard" || petName == "Lizard Hatchling" || petName == "Plains Monitor" || petName == "Spiky Lizard" || petName == "Spiny Lizard" || petName == "Twilight Iguana")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Claw" 			),	// Slot 1
-			new AandC("Quick Attack" 	),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Triple Snap" 	),	// Slot 2
-			new AandC("Comeback" 		),	// Slot 3
-			new AandC("Ravage" 			),	// Slot 3
-		};
-            else if (petName == "Scalded Basilisk Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Crystal Prison" 	),	// Slot 1
-			new AandC("Roar" 			),	// Slot 2
-			new AandC("Feign Death" 	),	// Slot 2
-			new AandC("Thrash" 			),	// Slot 3
-			new AandC("Screech" 		),	// Slot 3
-		};
-            else if (petName == "Warpstalker Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Claw" 			),	// Slot 1
-			new AandC("Blinkstrike" 	),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Triple Snap" 	),	// Slot 2
-			new AandC("Ravage" 			),	// Slot 3
-			new AandC("Comeback" 		),	// Slot 3
-		};
-            //////////////
-            // PRIMATES //
-            //////////////
-            else if (petName == "Baby Ape" || petName == "Bananas" || petName == "Darkmoon Monkey")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Smash" 			),	// Slot 1
-			new AandC("Rake" 			),	// Slot 1
-			new AandC("Roar" 			),	// Slot 2
-			new AandC("Clobber" 		),	// Slot 2
-			new AandC("Banana Barrage" 	),	// Slot 3
-			new AandC("Barrel Toss" 	),	// Slot 3
-		};
-            ////////////-
-            // RAPTORS //
-            ////////////-
-            else if (petName == "Darting Hatchling" || petName == "Deviate Hatchling" || petName == "Gundrak Hatchling" || petName == "Lashtail Hatchling" || petName == "Leaping Hatchling" || petName == "Obsidian Hatchling" || petName == "Ravasaur Hatchling" || petName == "Razormaw Hatchling" || petName == "Razzashi Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Devour", 	() =>		hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC("Leap", 		() =>	speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Flank" 			),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Exposed Wounds" 	),	// Slot 3
-		};
-            else if (petName == "Zandalari Anklerender")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Devour", () =>		hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC("Leap", 	() =>		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC("Black Claw", () => !debuff("Black Claw") 		),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Hunting Party" 	),	// Slot 1
-			new AandC("Primal Cry" 		),	// Slot 2
-			new AandC("Leap"            ),	// Slot 3    -  unconditional Leap           
-		};
-            else if (petName == "Zandalari Footslasher")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Leap", () =>			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Hunting Party" 	),	// Slot 1
-			new AandC("Primal Cry" 		),	// Slot 2
-			new AandC("Bloodfang" 		),	// Slot 3
-			new AandC("Exposed Wounds" 	),	// Slot 3
-		};
-            else if (petName == "Zandalari Kneebiter")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Leap", () =>			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 3
-			new AandC("Black Claw", () => !debuff("Black Claw") ),	// Slot 2
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Hunting Party" 	),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Bloodfang" 		),	// Slot 3
-			new AandC("Leap"            ),	// Slot 3    -  unconditional Leap           
-		};
-            else if (petName == "Zandalari Toenibbler")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Leap", () =>			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC("Black Claw", () => !debuff("Black Claw") ),	// Slot 2
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Flank" 			),	// Slot 1
-			new AandC("Primal Cry" 		),	// Slot 2
-			new AandC("Bloodfang" 		),	// Slot 3
-			new AandC("Leap"            ),	// Slot 3    -  unconditional Leap           
-		};
-            ////////////-
-            // RODENTS //
-            ////////////-
-            else if (petName == "Bucktooth Flapper")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 2
-			new AandC("Tail Slap" 		),	// Slot 1
-			new AandC("Gnaw" 			),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Woodchipper" 	),	// Slot 3
-			new AandC("Chew" 			),	// Slot 3
-		}
-            ;
-            else if (petName == "Clouded Hedgehog")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 2
-			new AandC("Counterstrike", () =>	speed < speedEnemy ),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Poison Fang" 	),	// Slot 1
-			new AandC("Spiked Skin" 	),	// Slot 2
-			new AandC("Powerball" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Silent Hedgehog")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Poison Fang" 	),	// Slot 1
-			new AandC("Spiked Skin" 	),	// Slot 2
-			new AandC("Counterstrike" 	),	// Slot 2
-			new AandC("Powerball" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Sumprush Rodent")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 2
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Powerball" 		),	// Slot 1
-			new AandC("Spirit Spikes" 	),	// Slot 2
-			new AandC("Flank" 			),	// Slot 2
-			new AandC("Vengeance" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Vengeful Porcupette")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 3
-			new AandC("Gnaw" 			),	// Slot 1
-			new AandC("Tail Slap" 		),	// Slot 1
-			new AandC("Mudslide" 		),	// Slot 2
-			new AandC("Poison Fang" 	),	// Slot 2
-			new AandC("Stench" 			),	// Slot 3
-		}
-                    //////////////-
-                    // SCORPIONS //
-                    //////////////-
-            ;
-            else if (petName == "Crunchy Scorpion" || petName == "Durotar Scorpion" || petName == "Leopard Scorpid" || petName == "Scorpid" || petName == "Scorpling" || petName == "Stripe-Tailed Scorpid")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Crouch" 			),	// Slot 2
-			new AandC("Sting", 	() =>		 ! debuff("Sting") ),	// Slot 3
-			new AandC("Snap" 			),	// Slot 1
-			new AandC("Triple Snap" 	),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Rampage" 		),	// Slot 3
-		}
-                    ////////////
-                    // SNAKES //
-                    ////////////
-            ;
-            else if (petName == "Adder" || petName == "Albino Snake" || petName == "Ash Viper" || petName == "Black Kingsnake" || petName == "Brown Snake" || petName == "Cobra Hatchling" || petName == "Coral Adder" || petName == "Coral Snake" || petName == "Crimson Snake" || petName == "Emerald Boa" || petName == "Grove Viper" || petName == "King Snake" || petName == "Moccasin" || petName == "Rat Snake" || petName == "Rattlesnake" || petName == "Rock Viper" || petName == "Sidewinder" || petName == "Snake" || petName == "Temple Snake" || petName == "Tree Python" || petName == "Water Snake" || petName == "Zooey Snake")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Burrow" 			),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Poison Fang" 	),	// Slot 1
-			new AandC("Hiss" 			),	// Slot 2
-			new AandC("Counterstrike" 	),	// Slot 2
-			new AandC("Vicious Fang" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Elder Python")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Poison Fang" 	),	// Slot 1
-			new AandC("Sting" 			),	// Slot 2
-			new AandC("Huge Fang" 		),	// Slot 2
-			new AandC("Burrow" 			),	// Slot 3
-			new AandC("Slither" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Death Adder Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Burrow" 			),	// Slot 3
-			new AandC("Poison Fang" 	),	// Slot 1
-			new AandC("Vicious Fang" 	),	// Slot 1
-			new AandC("Puncture Wound" 	),	// Slot 2
-			new AandC("Crouch" 			),	// Slot 2
-			new AandC("Blinding Poison" ),	// Slot 3
-		}
-                    ////////////
-                    // SPIDERS //
-                    ////////////
-            ;
-            else if (petName == "Amethyst Spiderling" || petName == "Ash Spiderling" || petName == "Desert Spider" || petName == "Dusk Spiderling" || petName == "Feverbite Hatchling" || petName == "Forest Spiderling" || petName == "Jumping Spider" || petName == "Skittering Cavern Crawler" || petName == "Smolderweb Hatchling" || petName == "Spider" || petName == "Twilight Spider" || petName == "Venomspitter Hatchling" || petName == "Widow Spiderling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Sticky Web",	() =>	 ! debuff("Webbed") ),  // Slot 2
-			new AandC("Brittle Webbing", () =>! debuff("Brittle Webbing") ),  // Slot 2
-			new AandC("Leech Life",	() =>	debuff("Webbed") || debuff("Brittle Webbing") ),  // Slot 3
-			new AandC("Spiderling Swarm", () => debuff("Webbed") || debuff("Brittle Webbing") ),  // Slot 3
-			new AandC("Strike" 			),	// Slot 1
-			new AandC("Poison Spit" 	),	// Slot 1
-		}
-            ;
-            else if (petName == "Crystal Spider")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Leech Life", () =>		hp < 0.7 ),	// Slot 3
-			new AandC("Strike" 			),	// Slot 1
-			new AandC("Crystal Prison" 	),	// Slot 1
-			new AandC("Sticky Web" 		),	// Slot 2
-			new AandC("Brittle Webbing" ),	// Slot 2
-			new AandC("Spiderling Swarm"),	// Slot 3
-		}
-            ;
-            else if (petName == "Molten Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Burn" 			),	// Slot 1
-			new AandC("Leech Life" 		),	// Slot 1
-			new AandC("Sticky Web" 		),	// Slot 2
-			new AandC("Cauterize" 		),	// Slot 2
-			new AandC("Magma Wave" 		),	// Slot 3
-			new AandC("Brittle Webbing" ),	// Slot 3
-		}
-                    //////////////-
-                    // UNGULATES //
-                    //////////////-
-            ;
-            else if (petName == "Clefthoof Runt")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 2
-			new AandC("Smash" 			),	// Slot 1
-			new AandC("Trample" 		),	// Slot 1
-			new AandC("Trumpet Strike" 	),	// Slot 2
-			new AandC("Horn Attack" 	),	// Slot 3
-			new AandC("Stampede"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Giraffe Calf")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 2
-			new AandC("Headbutt" 		),	// Slot 3
-			new AandC("Hoof" 			),	// Slot 1
-			new AandC("Stampede" 		),	// Slot 1
-			new AandC("Tranquility" 	),	// Slot 2
-			new AandC("Bleat"			),	// Slot 3
-		}
-            ;
-            else if (petName == "Little Black Ram" || petName == "Summit Kid")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Headbutt" 		),	// Slot 3
-			new AandC("Hoof" 			),	// Slot 1
-			new AandC("Chew" 			),	// Slot 1
-			new AandC("Comeback" 		),	// Slot 2
-			new AandC("Soothe" 			),	// Slot 2
-			new AandC("Stampede"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Stunted Shardhorn")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Survival", () =>		hp < 0.3 ),	// Slot 1
-			new AandC("Smash" 			),	// Slot 1
-			new AandC("Trample" 		),	// Slot 2
-			new AandC("Horn Attack" 	),	// Slot 2
-			new AandC("Trumpet Strike" 	),	// Slot 3
-			new AandC("Stampede"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Zao, Calfling of Niuzao")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Headbutt" 		),	// Slot 2
-			new AandC("Trample" 		),	// Slot 1
-			new AandC("Horn Gore" 		),	// Slot 1
-			new AandC("Wish" 			),	// Slot 2
-			new AandC("Niuzao's Charge" ),	// Slot 3
-			new AandC("Dominance"		),	// Slot 3
-		}
-                    //////////////////-
-                    // MISCELLANEOUS //
-                    //////////////////-
-            ;
-            else if (petName == "Mountain Panda")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Scratch" 		),	// Slot 1
-			new AandC("Cute Face" 		),	// Slot 2
-			new AandC("Rock Barrage" 	),	// Slot 2
-			new AandC("Burrow" 			),	// Slot 3
-			new AandC("Mudslide"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Ravager Hatchling")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Devour", () =>			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Rend" 			),	// Slot 1
-			new AandC("Screech" 		),	// Slot 2
-			new AandC("Sting" 			),	// Slot 2
-			new AandC("Rampage"			),	// Slot 3
-		}
-            ;
-            else if (petName == "Red Panda")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Scratch" 		),	// Slot 1
-			new AandC("Crouch" 			),	// Slot 2
-			new AandC("Cute Face" 		),	// Slot 2
-			new AandC("Perk Up" 		),	// Slot 3
-			new AandC("Hibernate"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Snowy Panda")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Snowball" 		),	// Slot 1
-			new AandC("Cute Face" 		),	// Slot 2
-			new AandC("Call Blizzard" 	),	// Slot 2
-			new AandC("Crouch" 			),	// Slot 3
-			new AandC("Ice Barrier"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Sunfur Panda")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Scratch" 		),	// Slot 1
-			new AandC("Hibernate" 		),	// Slot 2
-			new AandC("Cute Face" 		),	// Slot 2
-			new AandC("Sunlight" 		),	// Slot 3
-			new AandC("Crouch"			),	// Slot 3
-		}
-            ;
-            else if (petName == "Wind Rider Cub")
-                beast_abilities = new List<AandC>() 
-		{
-			new AandC("Lift-Off"		),	// Slot 3
-			new AandC("Bite" 			),	// Slot 1
-			new AandC("Squawk" 			),	// Slot 1
-			new AandC("Slicing Wind" 	),	// Slot 2
-			new AandC("Adrenaline Rush" ),	// Slot 2
-			new AandC("Flock" 			),	// Slot 3
-		};
-            //////////////////-
-            //////////////////-
-            else // Unknown beast
+            switch (petName)
             {
-                Logger.Alert("Unknown beast pet: " + petName);
-                return null;
+                case "Adder": 
+                case "Albino Snake": 
+                case "Ash Viper": 
+                case "Black Kingsnake": 
+                case "Brown Snake": 
+                case "Cobra Hatchling": 
+                case "Coral Adder": 
+                case "Coral Snake": 
+                case "Crimson Snake": 
+                case "Emerald Boa": 
+                case "Grove Viper": 
+                case "King Snake": 
+                case "Moccasin": 
+                case "Rat Snake": 
+                case "Rattlesnake": 
+                case "Rock Viper": 
+                case "Sidewinder": 
+                case "Snake": 
+                case "Temple Snake": 
+                case "Tree Python": 
+                case "Water Snake": 
+                case "Zooey Snake":
+                    /* Abilities:
+                     * Slot 1: Bite     | Poison Fang
+                     * Slot 2: Hiss     | Counterstrike
+                     * Slot 3: Burrow   | Vicious Fang
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Bite"),
+                        new AandC("Poison Fang"),
+                        new AandC("Hiss"),
+                        new AandC("Counterstrike"),
+                        new AandC("Vicious Fang"),
+                    };
+                    break;
+
+
+                case "Albino River Calf":
+                case "Flat-Tooth Calf":
+                case "Mudback Calf":
+                    /* Changelog:
+                     * 2015-01-20: Clobber is now checking for all stun and resilience effects - Studio60
+                     * 2015-01-19: Clobber is only used if the enemy is not Resilient - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Bite     | Water Jet
+                     * Slot 2: Takedown | Stoneskin
+                     * Slot 3: Clobber  | Headbutt
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Takedown",   () => enemyIsStunned()),
+                        new AandC("Stoneskin",  () => ! buff("Stoneskin")),
+                        new AandC("Clobber",    () => ! enemyIsResilient() && ! enemyIsStunned()),
+                        new AandC("Headbutt"),
+                        new AandC("Bite"),
+                        new AandC("Water Jet"),
+                    };
+                    break;
+
+                case "Alpine Foxling":
+                case "Alpine Foxling Kit":
+                case "Arctic Fox Kit": 
+                case "Fjord Worg Pup": 
+                case "Fox Kit": 
+                case "Worg Pup":
+                    /* Abilities:
+                     * Slot 1: Bite     | Flurry
+                     * Slot 2: Crouch   | Howl
+                     * Slot 3: Leap     | Dazzling Dance
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Dazzling Dance",   () => speed < speedEnemy && ! buff("Dazzling Dance")),
+                        new AandC("Leap",             () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Bite"),
+                        new AandC("Flurry"),
+                        new AandC("Crouch"),
+                        new AandC("Howl"),
+                    };
+                    break;
+
+                case "Alterac Brew-Pup":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Bite             | Bark
+                     * Slot 2: The Good Stuff   | Tough n' Cuddly
+                     * Slot 3: Avalanche        | Call the Pack
+                     * 
+                     * TODO: The Good Stuff needs to check if own team needs heal
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Tough n' Cuddly",    () => ! buff("Tough n' Cuddly")),
+                        new AandC("Avalanche"),
+                        new AandC("Call the Pack"),
+                        new AandC("Bite"),
+                        new AandC("Bark"),
+                        new AandC("The Good Stuff"),
+                    };
+                    break;
+
+                case "Amethyst Spiderling": 
+                case "Ash Spiderling": 
+                case "Desert Spider": 
+                case "Dusk Spiderling": 
+                case "Feverbite Hatchling": 
+                case "Forest Spiderling": 
+                case "Jumping Spider": 
+                case "Skittering Cavern Crawler": 
+                case "Smolderweb Hatchling": 
+                case "Spider": 
+                case "Twilight Spider": 
+                case "Venomspitter Hatchling": 
+                case "Widow Spiderling":
+                    /* Abilities:
+                     * Slot 1: Strike       | Poison Spit
+                     * Slot 2: Sticky Web   | Brittle Webbing
+                     * Slot 3: Leech Life   | Spiderling Swarm
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Sticky Web",       () => ! debuff("Webbed")),
+                        new AandC("Brittle Webbing",  () => ! debuff("Brittle Webbing")),
+                        new AandC("Leech Life",       () => debuff("Webbed") || debuff("Brittle Webbing")),
+                        new AandC("Spiderling Swarm", () => debuff("Webbed") || debuff("Brittle Webbing")),
+                        new AandC("Strike"),
+                        new AandC("Poison Spit"),
+                    };
+                    break;
+
+                case "Argi":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Gnaw                 | Horn Gore
+                     * Slot 2: Gift of the Naaru    | Chew
+                     * Slot 3: Stampede             | Headbutt
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Gift of the Naaru",  () => hp < 0.7),
+                        new AandC("Chew"),
+                        new AandC("Stampede",           () => ! debuff("Shattered Defenses")),
+                        new AandC("Headbutt"),
+                        new AandC("Gnaw"),
+                        new AandC("Horn Gore"),
+                    };
+                    break;
+
+                case "Ash Lizard": 
+                case "Diemetradon Hatchling": 
+                case "Horned Lizard": 
+                case "Lizard Hatchling": 
+                case "Plains Monitor": 
+                case "Spiky Lizard": 
+                case "Spiny Lizard": 
+                case "Twilight Iguana":
+                    /* Abilities:
+                     * Slot 1: Claw     | Quick Attack
+                     * Slot 2: Screech  | Triple Snap
+                     * Slot 3: Comeback | Ravage
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Quick Attack"),
+                        new AandC("Screech"),
+                        new AandC("Triple Snap"),
+                        new AandC("Comeback"),
+                        new AandC("Ravage"),
+                    };
+                    break;
+
+                case "Baby Ape": 
+                case "Bananas": 
+                case "Darkmoon Monkey":
+                    /* Abilities:
+                     * Slot 1: Smash            | Rake
+                     * Slot 2: Roar             | Clobber
+                     * Slot 3: Banana Barrage   | Barrel Toss
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Smash"),
+                        new AandC("Rake"),
+                        new AandC("Roar"),
+                        new AandC("Clobber"),
+                        new AandC("Banana Barrage"),
+                        new AandC("Barrel Toss"),
+                    };
+                    break;
+
+                case "Baby Blizzard Bear":
+                case "Poley":
+                    /* Abilities:
+                     * Slot 1: Bite | Roar
+                     * Slot 2: Bash | Hibernate
+                     * Slot 3: Maul | Call Blizzard
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Roar"),
+                        new AandC("Bash"),
+                        new AandC("Hibernate"),
+                        new AandC("Maul"),
+                        new AandC("Call Blizzard"),
+                    };
+                    break;
+
+                case "Black Tabby Cat": 
+                case "Bombay Cat": 
+                case "Calico Cat": 
+                case "Cat": 
+                case "Cheetah Cub": 
+                case "Cornish Rex Cat": 
+                case "Darkmoon Cub": 
+                case "Nightsaber Cub": 
+                case "Orange Tabby Cat": 
+                case "Panther Cub": 
+                case "Sand Kitten": 
+                case "Siamese Cat": 
+                case "Silver Tabby Cat": 
+                case "Snow Cub": 
+                case "White Kitten": 
+                case "Winterspring Cub":
+                    /* Abilities:
+                     * Slot 1: Claw     | Pounce
+                     * Slot 2: Rake     | Screech
+                     * Slot 3: Devour   | Prowl
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour", () => hpEnemy < 0.20 ),
+                        new AandC("Claw"),
+                        new AandC("Pounce"),
+                        new AandC("Rake"),
+                        new AandC("Screech"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                case "Bucktooth Flapper":
+                    /* Abilities:
+                     * Slot 1: Tail Slap    | Gnaw
+                     * Slot 2: Screech      | Survival
+                     * Slot 3: Woodchipper  | Chew
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival", () => hp < 0.3 ),
+                        new AandC("Tail Slap"),
+                        new AandC("Gnaw"),
+                        new AandC("Screech"),
+                        new AandC("Woodchipper"),
+                        new AandC("Chew"),
+                    };
+                    break;
+
+                case "Clefthoof Runt":
+                    /* Abilities:
+                     * Slot 1: Smash | Trample
+                     * Slot 2: Survival | Trumpet Strike
+                     * Slot 3: Horn Attack | Stampede
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",         () => hp < 0.3),
+                        new AandC("Smash"),
+                        new AandC("Trample"),
+                        new AandC("Trumpet Strike"),
+                        new AandC("Horn Attack"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Clouded Hedgehog":
+                    /* Abilities:
+                     * Slot 1: Bite             | Poison Fang
+                     * Slot 2: Survival         | Spiked Skin
+                     * Slot 3: Counterstrike    | Powerball
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",         () => hp < 0.3 ),
+                        new AandC("Counterstrike",    () =>  speed < speedEnemy ),
+                        new AandC("Bite"),
+                        new AandC("Poison Fang"),
+                        new AandC("Spiked Skin"),
+                        new AandC("Powerball"),
+                    };
+                    break;
+
+                case "Crunchy Scorpion": 
+                case "Durotar Scorpion": 
+                case "Leopard Scorpid": 
+                case "Scorpid": 
+                case "Scorpling": 
+                case "Stripe-Tailed Scorpid":
+                    /* Abilities:
+                     * Slot 1: Snap     | Triple Snap
+                     * Slot 2: Crouch   | Screech
+                     * Slot 3: Sting    | Rampage
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Crouch"),
+                        new AandC("Sting",        () => ! debuff("Sting")),
+                        new AandC("Snap"),
+                        new AandC("Triple Snap"),
+                        new AandC("Screech"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+
+                case "Crystal Spider":
+                    /* Abilities:
+                     * Slot 1: Strike | Crystal Prison
+                     * Slot 2: Sticky Web | Brittle Webbing
+                     * Slot 3: Leech Life | Spiderling Swarm
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leech Life", () => hp < 0.7),
+                        new AandC("Strike"),
+                        new AandC("Crystal Prison"),
+                        new AandC("Sticky Web"),
+                        new AandC("Brittle Webbing"),
+                        new AandC("Spiderling Swarm"),
+                    };
+                    break;
+
+                case "Darkshore Cub": 
+                case "Dun Morogh Cub": 
+                case "Hyjal Bear Cub": 
+                case "Panda Cub":
+                    /* Abilities:
+                     * Slot 1: Bite         | Roar
+                     * Slot 2: Hibernate    | Bash
+                     * Slot 3: Maul         | Rampage
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Roar"),
+                        new AandC("Hibernate"),
+                        new AandC("Bash"),
+                        new AandC("Maul"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+
+                case "Darting Hatchling": 
+                case "Deviate Hatchling": 
+                case "Gundrak Hatchling": 
+                case "Lashtail Hatchling": 
+                case "Leaping Hatchling": 
+                case "Obsidian Hatchling": 
+                case "Ravasaur Hatchling": 
+                case "Razormaw Hatchling": 
+                case "Razzashi Hatchling":
+                    /* Abilities:
+                     * Slot 1: Bite     | Flank
+                     * Slot 2: Leap     | Screech
+                     * Slot 3: Devour   | Exposed Wounds
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",           () => hpEnemy < 0.20 ),
+                        new AandC("Leap",             () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Bite"),
+                        new AandC("Flank"),
+                        new AandC("Screech"),
+                        new AandC("Exposed Wounds"),
+                    };
+                    break;
+
+                case "Deathwatch Hatchling":
+                    /* Changelog:
+                     * 2015-01-20: Clobber is now checking for all stun and resilience effects - Studio60
+                     *             Takedown is now checking for all stun effects - Studio60
+                     * 2015-01-19: Clobber is only used if the enemy is not Resilient - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Woodchipper  | Bite
+                     * Slot 2: Feed         | Clobber
+                     * Slot 3: Takedown     | Leap
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Feed",           () => hp < 0.7),
+                        new AandC("Clobber",        () => ! enemyIsStunned() && ! enemyIsResilient()),
+                        new AandC("Takedown",       () => enemyIsStunned()),
+                        new AandC("Leap"),
+                        new AandC("Woodchipper"),
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Death Adder Hatchling":
+                    /* Abilities:
+                     * Slot 1: Poison Fang      | Vicious Fang
+                     * Slot 2: Puncture Wound   | Crouch
+                     * Slot 3: Burrow           | Blinding Poison
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Poison Fang"),
+                        new AandC("Vicious Fang"),
+                        new AandC("Puncture Wound"),
+                        new AandC("Crouch"),
+                        new AandC("Blinding Poison"),
+                    };
+                    break;
+
+                case "Devouring Maggot": 
+                case "Festering Maggot": 
+                case "Jungle Grub": 
+                case "Larva": 
+                case "Maggot": 
+                case "Mr. Grubbs":
+                    /* Abilities:
+                     * Slot 1: Chomp | Consume
+                     * Slot 2: Acidic Goo | Sticky Goo
+                     * Slot 3: Leap | Burrow
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",         () => ! buff("Speed Boost") && (speed < speedEnemy)),
+                        new AandC("Acidic Goo",   () => ! debuff("Acidic Goo")),
+                        new AandC("Chomp"),
+                        new AandC("Consume"),
+                        new AandC("Sticky Goo"),
+                        new AandC("Burrow"),
+                    };
+                    break;
+
+                case "Direhorn Runt": 
+                case "Pygmy Direhorn": 
+                case "Stunted Direhorn":
+                    /* Abilities:
+                     * Slot 1: Trihorn Charge   | Trample
+                     * Slot 2: Horn Attack      | Stampede
+                     * Slot 3: Primal Cry       | Trihorn Shield
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Trihorn Charge"),
+                        new AandC("Trample"),
+                        new AandC("Horn Attack"),
+                        new AandC("Stampede"),
+                        new AandC("Primal Cry"),
+                        new AandC("Trihorn Shield"),
+                    };
+                    break;
+
+                case "Elder Python":
+                    /* Abilities:
+                     * Slot 1: Bite     | Poison Fang
+                     * Slot 2: Sting    | Huge Fang
+                     * Slot 3: Burrow   | Slither
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Poison Fang"),
+                        new AandC("Sting"),
+                        new AandC("Huge Fang"),
+                        new AandC("Burrow"),
+                        new AandC("Slither"),
+                    };
+                    break;
+
+                case "Feline Familiar":
+                    /* Abilities:
+                     * Slot 1: Onyx Bite    | Pounce
+                     * Slot 2: Stoneskin    | Call Darkness
+                     * Slot 3: Devour       | Prowl
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",           () => hpEnemy < 0.20),
+                        new AandC("Onyx Bite"),
+                        new AandC("Pounce"),
+                        new AandC("Stoneskin"),
+                        new AandC("Call Darkness"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                case "Frostwolf Pup":
+                    /* Changelog:
+                     * 2015-01-20: Howl now correctly considers the "Shattered Defenses" debuff on the enemy - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Bite     | Flurry
+                     * Slot 2: Crouch   | Howl
+                     * Slot 3: Maul     | Vengeance
+                     * 
+                     * TODO: Vengeance should know how large the last hit was
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Crouch",     () => ! buff("Crouch")),
+                        new AandC("Howl",       () => ! debuff("Shattered Defenses")),
+                        new AandC("Maul"),
+                        new AandC("Bite"),
+                        new AandC("Flurry"),
+                        new AandC("Vengeance"),
+                    };
+                    break;
+
+                case "Giraffe Calf":
+                    /* Abilities:
+                     * Slot 1: Hoof         | Stampede
+                     * Slot 2: Tranquility  | Survival
+                     * Slot 3: Headbutt     | Bleat
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",     () => hp < 0.3),
+                        new AandC("Headbutt"),
+                        new AandC("Hoof"),
+                        new AandC("Stampede"),
+                        new AandC("Tranquility"),
+                        new AandC("Bleat"),
+                    };
+                    break;
+
+                case "Icespine Hatchling":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Gnaw             | Bite
+                     * Slot 2: Ravage           | Body Slam
+                     * Slot 3: Puncture Wound   | Takedown
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Ravage",         () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Body Slam"),
+                        new AandC("Puncture Wound"),
+                        new AandC("Takedown"),
+                        new AandC("Gnaw"),
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Leatherhide Runt":
+                    /* Changelog:
+                     * 2015-01-20: Survival is now only used to hide from huge attacks if it is faster or of both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Smash        | Trample
+                     * Slot 2: Survival     | Trumpet Strike
+                     * Slot 3: Horn Attack  | Stampede
+                     */
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Survival",       () => shouldIHide && hp < 0.3 && speed >= speedEnemy),
+                        new AandC("Trumpet Strike", () => ! buff("Attack Boost")),
+                        new AandC("Horn Attack"),
+                        new AandC("Stampede",       () => ! debuff("Shattered Defenses")),
+                        new AandC("Smash"),
+                        new AandC("Trample"),
+                    };
+                    break;
+
+                case "Little Black Ram":
+                case "Summit Kid":
+                    /* Abilities:
+                     * Slot 1: Hoof     | Chew
+                     * Slot 2: Comeback | Soothe
+                     * Slot 3: Headbutt | Stampede
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Headbutt"),
+                        new AandC("Hoof"),
+                        new AandC("Chew"),
+                        new AandC("Comeback"),
+                        new AandC("Soothe"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Kovok":
+                    /* Abilities:
+                     * Slot 1: Poison Fang  | Body Slam
+                     * Slot 2: Pheromones   | Digest Brains
+                     * Slot 3: Black Claw   | Puncture Wound
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Poison Fang"),
+                        new AandC("Body Slam"),
+                        new AandC("Pheromones"),
+                        new AandC("Digest Brains"),
+                        new AandC("Black Claw"),
+                        new AandC("Puncture Wound"),
+                    };
+                    break;
+
+                case "Meadowstomper Calf":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Trample      | Smash
+                     * Slot 2: Primal Cry   | Tough n' Cuddly
+                     * Slot 3: Headbutt     | Stampede
+                     */
+                    // stampede: not doing it twice in a row
+                    beast_abilities = new List<AandC>() {
+                        new AandC("Primal Cry",         () => ! debuff("Speed Reduction")),
+                        new AandC("Tough n' Cuddly",    () => ! buff("Tough n' Cuddly")),
+                        new AandC("Headbutt"),
+                        new AandC("Stampede",           () => ! debuff("Shattered Defenses")),
+                        new AandC("Trample"),
+                        new AandC("Smash"),
+                    };
+                    break;
+
+                case "Molten Hatchling":
+                    /* Abilities:
+                     * Slot 1: Burn         | Leech Life
+                     * Slot 2: Sticky Web   | Cauterize
+                     * Slot 3: Magma Wave   | Brittle Webbing
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burn"),
+                        new AandC("Leech Life"),
+                        new AandC("Sticky Web"),
+                        new AandC("Cauterize"),
+                        new AandC("Magma Wave"),
+                        new AandC("Brittle Webbing"),
+                    };
+                    break;
+
+                case "Moon Moon":
+                    /* Abilities:
+                     * Slot 1: Moon Fang    | Bite
+                     * Slot 2: Howl         | Crouch
+                     * Slot 3: Moon Tears   | Moon Dance
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Moon Fang"),
+                        new AandC("Bite"),
+                        new AandC("Howl"),
+                        new AandC("Crouch"),
+                        new AandC("Moon Tears"),
+                        new AandC("Moon Dance"),
+                    };
+                    break;
+
+                case "Mossbite Skitterer":
+                    /* Abilities:
+                     * Slot 1: Gnaw | Bite
+                     * Slot 2: Ravage | Body Slam
+                     * Slot 3: Puncture Wound | Takedown
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Gnaw",             () => speed > speedEnemy),
+                        new AandC("Ravage",           () => hpEnemy < 0.2),
+                        new AandC("Puncture Wound",   () => debuff("Poisoned")),
+                        new AandC("Takedown",         () => debuff("Stunned")),
+                        new AandC("Body Slam"),
+                        new AandC("Gnaw"),
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Mountain Panda":
+                    /* Abilities:
+                     * Slot 1: Bite | Scratch
+                     * Slot 2: Cute Face | Rock Barrage
+                     * Slot 3: Burrow | Mudslide
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Scratch"),
+                        new AandC("Cute Face"),
+                        new AandC("Rock Barrage"),
+                        new AandC("Burrow"),
+                        new AandC("Mudslide"),
+                    };
+                    break;
+
+                case "Parched Lizard":
+                    /* Changelog:
+                     * 2015-01-20: Conflagrate been added - Studio60
+                     *             Screech is now used if it is not already active - Studio60
+                     *             Comeback is now only used if pet health is lower than enemy health - Studio60
+                     *             Ravage is now used on enemies with low health - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Claw | Quick Attack
+                     * Slot 2: Screech | Conflagrate
+                     * Slot 3: Comeback | Ravage
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Screech",      () => ! debuff("Speed Reduction")),
+                        new AandC("Conflagrate",  () => enemyIsBurning()),
+                        new AandC("Comeback",     () => hp < hpEnemy),
+                        new AandC("Ravage",       () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Claw"),
+                        new AandC("Quick Attack"),
+                    };
+                    break;
+                
+                case "Ravager Hatchling":
+                    /* Abilities:
+                     * Slot 1: Bite     | Rend
+                     * Slot 2: Screech  | Sting
+                     * Slot 3: Devour   | Rampage
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour", () => hpEnemy < 0.20),
+                        new AandC("Bite"),
+                        new AandC("Rend"),
+                        new AandC("Screech"),
+                        new AandC("Sting"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+
+                case "Red Panda":
+                    /* Abilities:
+                     * Slot 1: Bite     | Scratch
+                     * Slot 2: Crouch   | Cute Face
+                     * Slot 3: Perk Up  | Hibernate
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Scratch"),
+                        new AandC("Crouch"),
+                        new AandC("Cute Face"),
+                        new AandC("Perk Up"),
+                        new AandC("Hibernate"),
+                    };
+                    break;
+
+                case "Scalded Basilisk Hatchling":
+                    /* Abilities:
+                     * Slot 1: Bite     | Crystal Prison
+                     * Slot 2: Roar     | Feign Death
+                     * Slot 3: Thrash   | Screech
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Crystal Prison"),
+                        new AandC("Roar"),
+                        new AandC("Feign Death"),
+                        new AandC("Thrash"),
+                        new AandC("Screech"),
+                    };
+                    break;
+
+                case "Silent Hedgehog":
+                    /* Abilities:
+                     * Slot 1: Bite         | Poison Fang
+                     * Slot 2: Spiked Skin  | Counterstrike
+                     * Slot 3: Survival     | Powerball
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",         () => hp < 0.3 ),
+                        new AandC("Bite"),
+                        new AandC("Poison Fang"),
+                        new AandC("Spiked Skin"),
+                        new AandC("Counterstrike"),
+                        new AandC("Powerball"),
+                    };
+                    break;
+
+                case "Silithid Hatchling":
+                    /* Abilities:
+                     * Slot 1: Scratch  | Devour
+                     * Slot 2: Hiss     | Survival
+                     * Slot 3: Swarm    | Sandstorm
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",     () => hp < 0.3),
+                        new AandC("Devour",       () => hpEnemy < 0.20 ),
+                        new AandC("Scratch"),
+                        new AandC("Hiss"),
+                        new AandC("Swarm"),
+                        new AandC("Sandstorm"),
+                    };
+                    break;
+
+                case "Snowy Panda":
+                    /* Abilities:
+                     * Slot 1: Bite         | Snowball
+                     * Slot 2: Cute Face    | Call Blizzard
+                     * Slot 3: Crouch       | Ice Barrier
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Snowball"),
+                        new AandC("Cute Face"),
+                        new AandC("Call Blizzard"),
+                        new AandC("Crouch"),
+                        new AandC("Ice Barrier"),
+                    };
+                    break;
+
+                case "Stunted Shardhorn":
+                    /* Abilities:
+                     * Slot 1: Smash            | Survival
+                     * Slot 2: Trample          | Horn Attack
+                     * Slot 3: Trumpet Strike   | Stampede
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival", () => hp < 0.3),
+                        new AandC("Smash"),
+                        new AandC("Trample"),
+                        new AandC("Horn Attack"),
+                        new AandC("Trumpet Strike"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Sumprush Rodent":
+                    /* Abilities:
+                     * Slot 1: Gnaw     | Tail Slap
+                     * Slot 2: Mudslide | Poison Fang
+                     * Slot 3: Survival | Stench
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",         () => hp < 0.3),
+                        new AandC("Bite"),
+                        new AandC("Powerball"),
+                        new AandC("Spirit Spikes"),
+                        new AandC("Flank"),
+                        new AandC("Vengeance"),
+                    };
+                    break;
+
+                case "Sunfur Panda":
+                    /* Abilities:
+                     * Slot 1: Bite         | Scratch
+                     * Slot 2: Hibernate    | Cute Face
+                     * Slot 3: Sunlight     | Crouch
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Scratch"),
+                        new AandC("Hibernate"),
+                        new AandC("Cute Face"),
+                        new AandC("Sunlight"),
+                        new AandC("Crouch"),
+                    };
+                    break;
+
+                case "Thicket Skitterer":
+                    /* Changelog:
+                     * 2015-01-20: Ravage is now used on enemies with low health - Studio60
+                     *             Puncture Wound is now checking for all poison effects - Studio60
+                     *             Takedown is now checking for all stun effects - Studio60
+                     *             Body Slam is now only used if it is effective - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Gnaw             | Bite
+                     * Slot 2: Ravage           | Body Slam
+                     * Slot 3: Puncture Wound   | Takedown
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Gnaw",           () => speed > speedEnemy ),
+                        new AandC("Ravage",         () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Puncture Wound", () => enemyIsPoisoned()),
+                        new AandC("Takedown",       () => enemyIsStunned()),
+                        new AandC("Body Slam",      () => strong("Body Slam")),
+                        new AandC("Gnaw"),
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Tito":
+                    /* Abilities:
+                     * Slot 1: Bite     | Triple Snap
+                     * Slot 2: Impale   | Howl
+                     * Slot 3: Cyclone  | Buried Treasure
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Bite"),
+                        new AandC("Triple Snap"),
+                        new AandC("Impale"),
+                        new AandC("Howl"),
+                        new AandC("Buried Treasure"),
+                    };
+                    break;
+
+                case "Vengeful Porcupette":
+                    /* Abilities:
+                     * Slot 1: Bite             | Powerball
+                     * Slot 2: Spirit Spikes    | Survival
+                     * Slot 3: Flank            | Vengeance
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival", () => hp < 0.3 ),
+                        new AandC("Gnaw"),
+                        new AandC("Tail Slap"),
+                        new AandC("Mudslide"),
+                        new AandC("Poison Fang"),
+                        new AandC("Stench"),
+                    };
+                    break;
+
+                case "Warpstalker Hatchling":
+                    /* Abilities:
+                     * Slot 1: Claw     | Blinkstrike
+                     * Slot 2: Screech  | Triple Snap
+                     * Slot 3: Ravage   | Comeback
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Blinkstrike"),
+                        new AandC("Screech"),
+                        new AandC("Triple Snap"),
+                        new AandC("Ravage"),
+                        new AandC("Comeback"),
+                    };
+                    break;
+
+                case "Wind Rider Cub":
+                    /* Abilities:
+                     * Slot 1: Bite         | Squawk
+                     * Slot 2: Slicing Wind | Adrenaline Rush
+                     * Slot 3: Flock        | Lift-OFf
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lift-Off"),
+                        new AandC("Bite"),
+                        new AandC("Squawk"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Adrenaline Rush"),
+                        new AandC("Flock"),
+                    };
+                    break;
+
+                case "Xu-Fu, Cub of Xuen":
+                    /* Abilities:
+                     * Slot 1: Spirit Claws | Bite
+                     * Slot 2: Feed         | Moonfire
+                     * Slot 3: Vengeance    | Prowl
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Spirit Claws"),
+                        new AandC("Bite"),
+                        new AandC("Feed"),
+                        new AandC("Moonfire"),
+                        new AandC("Vengeance"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                case "Zandalari Anklerender":
+                    /* Abilities:
+                     * Slot 1: Bite | Hunting Party
+                     * Slot 2: Leap | Primal Cry
+                     * Slot 3: Devour | Black Claw
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",         () => hpEnemy < 0.20 ),
+                        new AandC("Leap",           () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Black Claw",     () => ! debuff("Black Claw")),
+                        new AandC("Bite"),
+                        new AandC("Hunting Party"),
+                        new AandC("Primal Cry"),
+                        new AandC("Leap"),
+                    };
+                    break;
+
+                case "Zandalari Footslasher":
+                    /* Abilities:
+                     * Slot 1: Bite         | Hunting Party
+                     * Slot 2: Leap         | Primal Cry
+                     * Slot 3: Bloodfang    | Exposed Wounds
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",           () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Bite"),
+                        new AandC("Hunting Party"),
+                        new AandC("Primal Cry"),
+                        new AandC("Bloodfang"),
+                        new AandC("Exposed Wounds"),
+                    };
+                    break;
+
+                case "Zandalari Kneebiter":
+                    /* Abilities:
+                     * Slot 1: Bite     | Hunting Party
+                     * Slot 2: Screech  | Black Claw
+                     * Slot 3: Leap     | Bloodfang
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap", () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Black Claw", () => !debuff("Black Claw")),
+                        new AandC("Bite"),
+                        new AandC("Hunting Party"),
+                        new AandC("Screech"),
+                        new AandC("Bloodfang"),
+                        new AandC("Leap"),
+                    };
+                    break;
+
+                case "Zandalari Toenibbler":
+                    /* Abilities:
+                     * Slot 1: Bite         | Flank
+                     * Slot 2: Leap         | Primal Cry
+                     * Slot 3: Bloodfang    | Black Claw
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Black Claw", () => !debuff("Black Claw")),
+                        new AandC("Bite"),
+                        new AandC("Flank"),
+                        new AandC("Primal Cry"),
+                        new AandC("Bloodfang"),
+                        new AandC("Leap"),
+                    };
+                    break;
+
+                case "Zao, Calfling of Niuzao":
+                    /* Abilities:
+                     * Slot 1: Trample          | Horn Gore
+                     * Slot 2: Headbutt         | Wish
+                     * Slot 3: Niuzao's Charge  | Dominance
+                     */
+                    beast_abilities = new List<AandC>() 
+                    {
+                        new AandC("Headbutt"),
+                        new AandC("Trample"),
+                        new AandC("Horn Gore"),
+                        new AandC("Wish"),
+                        new AandC("Niuzao's Charge"),
+                        new AandC("Dominance"),
+                    };
+                    break;
+
+                default:
+                    ///////////////////////
+                    // Unknown Beast Pet //
+                    ///////////////////////
+                    Logger.Alert("Unknown beast pet: " + petName);
+                    beast_abilities = null;
+                    break;
             }
+
             return beast_abilities;
         }
     }

--- a/Prosto_Pets/Pets/Critter.cs
+++ b/Prosto_Pets/Pets/Critter.cs
@@ -1,6 +1,6 @@
-////////////////
+/////////////
 // CRITTER //
-////////////////
+/////////////
 
 using System;
 using System.Collections.Generic;
@@ -24,341 +24,642 @@ namespace Prosto_Pets
 
             List<AandC> critter_abilities;
 
+            switch (petName) {
+                case "Alpine Chipmunk": 
+                case "Grizzly Squirrel": 
+                case "Nuts": 
+                case "Red-Tailed Chipmunk": 
+                case "Squirrel":
+                    /* Abilities:
+                     * Slot 1: Scratch          | Woodchipper
+                     * Slot 2: Adrenaline Rush  | Crouch
+                     * Slot 3: Nut Barrage      | Stampede
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Adrenaline Rush", () => speed < speedEnemy && ! buff("Adrenaline")),
+                        new AandC("Scratch"),
+                        new AandC("Woodchipper"),
+                        new AandC("Crouch"),
+                        new AandC("Nut Barrage"),
+                        new AandC("Stampede"),
+                    };
+                    break;
 
-////////////////
-// ARMADILLOS //
-////////////////
-            if (petName == "Armadillo Pup" || petName == "Stone Armadillo")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Roar" 			),	// Slot 2
-			new AandC( "Infected Claw" 	),	// Slot 3
-			new AandC( "Powerball" 		),	// Slot 3
-		}
-                    //////////-
-                    // BIRDS //
-                    //////////-
-            ;
-            else if (petName == "Darkmoon Hatchling")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Hawk Eye",	() =>	! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Trample" 		),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 2
-			new AandC( "Flock" 			),	// Slot 3
-			new AandC( "Predatory Strike"),	// Slot 3
-		}
-            ;
-            else if (petName == "Egbert" || petName == "Mulgore Hatchling")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Adrenaline Rush",  () =>speed < speedEnemy && ! buff("Adrenaline") ),	// Slot 2
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Trample" 		),	// Slot 3
-			new AandC( "Feign Death" 	),	// Slot 3
-		}
-                    //////////
-                    // DEER //
-                    //////////
-            ;
-            else if (petName == "Fawn" || petName == "Gazelle Fawn" || petName == "Little Fawn" || petName == "Winter Reindeer")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Tranquility", () => 	hp < 0.7 && ! buff("Tranquility") ),	// Slot 2
-			new AandC( "Bleat", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Hoof" 			),	// Slot 1
-			new AandC( "Stampede" 		),	// Slot 1
-			new AandC( "Nature's Ward" 	),	// Slot 2
-		}
-                    ////////////
-                    // ELEKKS //
-                    ////////////
-            ;
-            else if (petName == "Peanut" || petName == "Pint-Sized Pink Pachyderm")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 2
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Smash" 			),	// Slot 1
-			new AandC( "Trample" 		),	// Slot 1
-			new AandC( "Trumpet Strike" 	),	// Slot 2
-			new AandC( "Stampede" 		),	// Slot 3
-		}
-                    ////////////-
-                    // INSECTS //
-                    ////////////-
-            ;
-            else if (petName == "Beetle" || petName == "Cockroach" || petName == "Creepy Crawly" || petName == "Crystal Beetle" || petName == "Death's Head Cockroach" || petName == "Deepholm Cockroach" || petName == "Dung Beetle" || petName == "Fire-Proof Roach" || petName == "Gold Beetle" || petName == "Irradiated Roach" || petName == "Locust" || petName == "Resilient Roach" || petName == "Roach" || petName == "Sand Scarab" || petName == "Savory Beetle" || petName == "Scarab Hatchling" || petName == "Stinkbug" || petName == "Tainted Cockroach" || petName == "Tol'vir Scarab" || petName == "Twilight Beetle" || petName == "Undercity Cockroach")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Flank" 			),	// Slot 1
-			new AandC( "Hiss" 			),	// Slot 2
-			new AandC( "Swarm" 			),	// Slot 3
-			new AandC( "Apocalypse" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Fire Beetle" || petName == "Lava Beetle")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Apocalypse" 		),	// Slot 3
-			new AandC( "Cauterize", () => hp < 0.7		),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Flank" 			),	// Slot 1
-			new AandC( "Hiss" 			),	// Slot 2
-			new AandC( "Scorched Earth" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Grassland Hopper" || petName == "Marsh Fiddler" || petName == "Red Cricket" || petName == "Singing Cricket")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Nature's Touch",  () =>hp < 0.7 ),	// Slot 3
-			new AandC( "Skitter" 		),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 1
-			new AandC( "Swarm" 			),	// Slot 2
-			new AandC( "Cocoon Strike" 	),	// Slot 2
-			new AandC( "Inspiring Song" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Imperial Silkworm")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Burrow" 			),	// Slot 3
-			new AandC( "Chomp" 			),	// Slot 1
-			new AandC( "Consume" 		),	// Slot 1
-			new AandC( "Sticky Goo" 		),	// Slot 2
-			new AandC( "Moth Balls" 		),	// Slot 2
-			new AandC( "Moth Dust" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Nether Roach")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 2
-			new AandC( "Flank" 			),	// Slot 3
-			new AandC( "Nether Blast" 	),	// Slot 1
-			new AandC( "Hiss" 			),	// Slot 1
-			new AandC( "Swarm" 			),	// Slot 2
-			new AandC( "Apocalypse" 		),	// Slot 3
-		}
-                    ////////////-
-                    // MARMOTS //
-                    ////////////-
-            ;
-            else if (petName == "Borean Marmot" || petName == "Brown Marmot" || petName == "Brown Prairie Dog" || petName == "Prairie Dog" || petName == "Yellow-Bellied Marmot")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Burrow" 			),	// Slot 3
-			new AandC( "Adrenaline Rush",  () => speed < speedEnemy && ! buff("Adrenaline") ),	// Slot 2
-			new AandC( "Leap", () => 			 speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 3
-			new AandC( "Chomp" 			),	// Slot 1
-			new AandC( "Comeback" 		),	// Slot 1
-			new AandC( "Crouch" 			),	// Slot 2
-		}
-                    //////////
-                    // PIGS //
-                    //////////
-            ;
-            else if (petName == "Golden Pig" || petName == "Lucky" || petName == "Mr. Wiggles" || petName == "Silver Pig")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Hoof" 			),	// Slot 1
-			new AandC( "Diseased Bite" 	),	// Slot 1
-			new AandC( "Crouch" 			),	// Slot 2
-			new AandC( "Buried Treasure" ),	// Slot 2
-			new AandC( "Uncanny Luck" 	),	// Slot 3
-		}
-                    ////////////-
-                    // RABBITS //
-                    ////////////-
-            ;
-            else if (petName == "Alpine Hare" || petName == "Arctic Hare" || petName == "Brown Rabbit" || petName == "Elfin Rabbit" || petName == "Grasslands Cottontail" || petName == "Hare" || petName == "Mountain Cottontail" || petName == "Rabbit" || petName == "Snowshoe Hare" || petName == "Snowshoe Rabbit" || petName == "Spring Rabbit" || petName == "Tolai Hare" || petName == "Tolai Hare Pup")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Burrow" 			),	// Slot 3
-			new AandC( "Dodge" 			),	// Slot 2
-			new AandC( "Adrenaline Rush",  () => speed < speedEnemy && ! buff("Adrenaline") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Stampede"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Darkmoon Rabbit")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Burrow" 			),	// Slot 3
-			new AandC( "Dodge" 			),	// Slot 2
-			new AandC( "Vicious Streak",  () =>speed < speedEnemy && ! buff("Vicious Streak") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Huge, Sharp Teeth!"),	// Slot 1
-			new AandC( "Stampede"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Wolpertinger")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Horn Attack" 	),	// Slot 1
-			new AandC( "Flyby" 			),	// Slot 2
-			new AandC( "Sleeping Gas" 	),	// Slot 2
-			new AandC( "Rampage"			),	// Slot 3
-		}
-                    //////////////////-
-                    // RATS && MICE //
-                    //////////////////-
-            ;
-            else if (petName == "Black Rat" || petName == "Carrion Rat" || petName == "Fjord Rat" || petName == "Giant Sewer Rat" || petName == "Highlands Mouse" || petName == "Long-tailed Mole" || petName == "Mouse" || petName == "Rat" || petName == "Redridge Rat" || petName == "Stormwind Rat" || petName == "Stowaway Rat" || petName == "Tainted Rat" || petName == "Undercity Rat" || petName == "Wharf Rat" || petName == "Yakrat" || petName == "Prairie Mouse")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () =>		hp < 0.3 ),	// Slot 3
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Comeback" 		),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 2
-			new AandC( "Poison Fang" 	),	// Slot 2
-			new AandC( "Stampede" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Grotto Vole" || petName == "Whiskers the Rat")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Sting" 			),	// Slot 2
-			new AandC( "Stampede" 		),	// Slot 3
-			new AandC( "Comeback"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Malayan Quillrat" || petName == "Malayan Quillrat Pup" || petName == "Porcupette" || petName == "Silent Hedgehog")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 3
-			new AandC( "Spiked Skin",  () =>  ! buff("Spiked Skin") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Poison Fang" 	),	// Slot 1
-			new AandC( "Counterstrike" 	),	// Slot 2
-			new AandC( "Powerball"		),	// Slot 3
-		}
-                    //////////-
-                    // SHEEP //
-                    //////////-
-            ;
-            else if (petName == "Black Lamb" || petName == "Elwynn Lamb")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Headbutt" 		),	// Slot 3
-			new AandC( "Hoof" 			),	// Slot 1
-			new AandC( "Chew" 			),	// Slot 1
-			new AandC( "Comeback" 		),	// Slot 2
-			new AandC( "Sooth" 			),	// Slot 2
-			new AandC( "Rampage"			),	// Slot 3
-		}
-                    //////////////////////
-                    // SKUNKS && COONS //
-                    //////////////////////
-            ;
-            else if (petName == "Bandicoon" || petName == "Bandicoon Kit" || petName == "Masked Tanuki" || petName == "Masked Tanuki Pup" || petName == "Shy Bandicoon")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 2
-			new AandC( "Poison Fang",  () =>  ! debuff("Poisoned") ),	// Slot 3
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Tongue Lash" 	),	// Slot 1
-			new AandC( "Counterstrike" 	),	// Slot 2
-			new AandC( "Powerball"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Highlands Skunk" || petName == "Mountain Skunk" || petName == "Skunk" || petName == "Stinker")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 2
-			new AandC( "Perk Up" 		),	// Slot 2
-			new AandC( "Stench" 			),	// Slot 3
-			new AandC( "Bleat"			),	// Slot 3
-		}
-                    ////////////
-                    // SNAILS //
-                    ////////////
-            ;
-            else if (petName == "Rapana Whelk" || petName == "Rusty Snail" || petName == "Scooter the Snail" || petName == "Shimmershell Snail" || petName == "Silkbead Snail")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Acidic Goo",  () =>	! debuff("Acidic Goo") ),	// Slot 2
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Headbutt"		),	// Slot 3
-			new AandC( "Dive" 			),	// Slot 3
-			new AandC( "Ooze Touch" 		),	// Slot 1
-			new AandC( "Absorb" 			),	// Slot 1
-		}
-                    //////////////-
-                    // SQUIRRELS //
-                    //////////////-
-            ;
-            else if (petName == "Alpine Chipmunk" || petName == "Grizzly Squirrel" || petName == "Nuts" || petName == "Red-Tailed Chipmunk" || petName == "Squirrel")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Adrenaline Rush",  () => speed < speedEnemy && ! buff("Adrenaline") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Woodchipper" 	),	// Slot 1
-			new AandC( "Crouch" 			),	// Slot 2
-			new AandC( "Nut Barrage" 	),	// Slot 3
-			new AandC( "Stampede" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Blighted Squirrel")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Adrenaline Rush",  () => speed < speedEnemy && ! buff("Adrenaline") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Woodchipper" 	),	// Slot 1
-			new AandC( "Crouch" 			),	// Slot 2
-			new AandC( "Rabid Strike" 	),	// Slot 3
-			new AandC( "Stampede" 		),	// Slot 3
-		}
-                    //////////////////-
-                    // MISCELLANEOUS //
-                    //////////////////-
-            ;
-            else if (petName == "Lucky Quilen Cub" || petName == "Perky Pug")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Burrow" 			),	// Slot 3
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Comeback" 		),	// Slot 1
-			new AandC( "Perk Up" 		),	// Slot 2
-			new AandC( "Buried Treasure" ),	// Slot 2
-			new AandC( "Trample" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Porcupette")
-                critter_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 3
-			new AandC( "Spiked Skin",  () =>  ! buff("Spiked Skin") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Poison Fang" 	),	// Slot 1
-			new AandC( "Counterstrike" 	),	// Slot 2
-			new AandC( "Powerball" 		),	// Slot 3
-		};
-            //////////////////-
+                case "Alpine Hare": 
+                case "Arctic Hare": 
+                case "Brown Rabbit": 
+                case "Elfin Rabbit": 
+                case "Grasslands Cottontail": 
+                case "Hare": 
+                case "Mountain Cottontail": 
+                case "Rabbit": 
+                case "Snowshoe Hare": 
+                case "Snowshoe Rabbit": 
+                case "Spring Rabbit": 
+                case "Tolai Hare": 
+                case "Tolai Hare Pup":
+                    /* Abilities:
+                     * Slot 1: Scratch          | Flurry
+                     * Slot 2: Adrenaline Rush  | Dodge
+                     * Slot 3: Burrow           | Stampede
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Dodge"),
+                        new AandC("Adrenaline Rush",    () => speed < speedEnemy && ! buff("Adrenaline")),
+                        new AandC("Scratch"),
+                        new AandC("Flurry"),
+                        new AandC("Stampede"),
+                    };
+                    break;
 
-            else // Unknown critter
-            {
-                Logger.Alert("Unknown critter pet: " + petName);
-                return null;
+                case "Armadillo Pup":
+                case "Stone Armadillo":
+                    /* Abilities:
+                     * Slot 1: Scratch          | Trash
+                     * Slot 2: Shell Shield     | Roar
+                     * Slot 3: Infected Claw    | Powerball
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shell Shield",  () =>  ! buff("Shell Shield")),
+                        new AandC("Scratch"),
+                        new AandC("Thrash"),
+                        new AandC("Roar"),
+                        new AandC("Infected Claw"),
+                        new AandC("Powerball"),
+                    };
+                    break;
+
+                case "Bandicoon": 
+                case "Bandicoon Kit": 
+                case "Masked Tanuki": 
+                case "Masked Tanuki Pup": 
+                case "Shy Bandicoon":
+                    /* Abilities:
+                     * Slot 1: Bite         | Tongue Lash
+                     * Slot 2: Survival     | Counterstrike
+                     * Slot 3: Poison Fang  | Powerball
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",       () => hp < 0.3),
+                        new AandC("Poison Fang",    () => ! debuff("Poisoned")),
+                        new AandC("Bite"),
+                        new AandC("Tongue Lash"),
+                        new AandC("Counterstrike"),
+                        new AandC("Powerball"),
+                    };
+                    break;
+
+                case "Beetle":
+                case "Cockroach": 
+                case "Creepy Crawly": 
+                case "Crystal Beetle": 
+                case "Death's Head Cockroach": 
+                case "Deepholm Cockroach": 
+                case "Dung Beetle": 
+                case "Fire-Proof Roach": 
+                case "Gold Beetle": 
+                case "Irradiated Roach": 
+                case "Locust": 
+                case "Resilient Roach": 
+                case "Roach": 
+                case "Sand Scarab": 
+                case "Savory Beetle": 
+                case "Scarab Hatchling": 
+                case "Stinkbug": 
+                case "Tainted Cockroach": 
+                case "Tol'vir Scarab": 
+                case "Twilight Beetle": 
+                case "Undercity Cockroach":
+                    /* Abilities:
+                     * Slot 1: Scratch  | Flank
+                     * Slot 2: Hiss     | Survival
+                     * Slot 3: Swarm    | Apocalypse
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",   () => hp < 0.3),
+                        new AandC("Scratch"),
+                        new AandC("Flank"),
+                        new AandC("Hiss"),
+                        new AandC("Swarm"),
+                        new AandC("Apocalypse"),
+                    };
+                    break;
+
+                case "Black Lamb":
+                case "Elwynn Lamb":
+                    /* Abilities:
+                     * Slot 1: Hoof     | Chew
+                     * Slot 2: Comeback | Soothe
+                     * Slot 3: Bleat    | Stampede
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Headbutt"),
+                        new AandC("Hoof"),
+                        new AandC("Chew"),
+                        new AandC("Comeback"),
+                        new AandC("Sooth"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+
+                case "Black Rat": 
+                case "Carrion Rat": 
+                case "Fjord Rat": 
+                case "Giant Sewer Rat": 
+                case "Highlands Mouse": 
+                case "Long-tailed Mole": 
+                case "Mouse": 
+                case "Rat": 
+                case "Redridge Rat": 
+                case "Prairie Mouse":
+                case "Stormwind Rat": 
+                case "Stowaway Rat": 
+                case "Tainted Rat": 
+                case "Undercity Rat": 
+                case "Wharf Rat": 
+                case "Yakrat":
+                    /* Abilities:
+                     * Slot 1: Scratch      | Comeback
+                     * Slot 2: Flurry       | Poison Fang
+                     * Slot 3: Stampede     | Survival
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival", () => hp < 0.3),
+                        new AandC("Scratch"),
+                        new AandC("Comeback"),
+                        new AandC("Flurry"),
+                        new AandC("Poison Fang"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Blighted Squirrel":
+                    /* Abilities:
+                     * Slot 1: Scratch          | Woodchipper
+                     * Slot 2: Adrenaline Rush  | Crouch
+                     * Slot 3: Rabid Strike     | Stampede
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Adrenaline Rush",    () => speed < speedEnemy && ! buff("Adrenaline")),
+                        new AandC("Scratch"),
+                        new AandC("Woodchipper"),
+                        new AandC("Crouch"),
+                        new AandC("Rabid Strike"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Borean Marmot": 
+                case "Brown Marmot": 
+                case "Brown Prairie Dog": 
+                case "Prairie Dog": 
+                case "Yellow-Bellied Marmot":
+                    /* Abilities:
+                     * Slot 1: Chomp    | Adrenaline Rush
+                     * Slot 2: Leap     | Crouch
+                     * Slot 3: Burrow   | Comeback
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Adrenaline Rush",    () => speed < speedEnemy && ! buff("Adrenaline")),
+                        new AandC("Leap",               () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Chomp"),
+                        new AandC("Comeback"),
+                        new AandC("Crouch"),
+                    };
+                    break;
+
+                case "Bush Chicken":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Flock    | Savage Talon
+                     * Slot 2: Squawk   | Rake
+                     * Slot 3: Headbutt | Cyclone
+                     *
+                     * Tactic Information:
+                     * Not quite sure where to go with this tactic... Flock is weird as a base attack
+                     */
+                    critter_abilities = new List<AandC>() {
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Squawk",         () => ! debuff("Attack Reduction")),
+                        new AandC("Rake"),
+                        new AandC("Headbutt"),
+                        new AandC("Flock"),
+                        new AandC("Savage Talon"),
+                    };
+                    break;
+
+                case "Darkmoon Hatchling":
+                    /* Abilities:
+                     * Slot 1: Peck     | Trample
+                     * Slot 2: Screech  | Hawk Eye
+                     * Slot 3: Flock    | Predatory Strike
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Peck"),
+                        new AandC("Trample"),
+                        new AandC("Screech"),
+                        new AandC("Flock"),
+                        new AandC("Predatory Strike"),
+                    };
+                    break;
+
+                case "Darkmoon Rabbit":
+                    /* Abilities:
+                     * Slot 1: Scratch          | Huge, Sharp Teeth!
+                     * Slot 2: Vicious Streak   | Dodge
+                     * Slot 3: Burrow           | Stampede
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Dodge"),
+                        new AandC("Vicious Streak",     () => speed < speedEnemy && ! buff("Vicious Streak") ),
+                        new AandC("Scratch"),
+                        new AandC("Huge, Sharp Teeth!"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Egbert":
+                case "Mulgore Hatchling":
+                    /* Abilities:
+                     * Slot 1: Bite         | Peck
+                     * Slot 2: Shell Shield | Adrenaline Rush
+                     * Slot 3: Trample      | Feign Death
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Adrenaline Rush",    () => speed < speedEnemy && ! buff("Adrenaline")),
+                        new AandC("Shell Shield",       () => ! buff("Shell Shield")),
+                        new AandC("Bite"),
+                        new AandC("Peck"),
+                        new AandC("Trample"),
+                        new AandC("Feign Death"),
+                    };
+                    break;
+
+                case "Fawn": 
+                case "Gazelle Fawn": 
+                case "Little Fawn": 
+                case "Winter Reindeer":
+                    /* Abilities:
+                     * Slot 1: Hoof         | Stampede
+                     * Slot 2: Tranquility  | Nature's Ward
+                     * Slot 3: Bleat        | Headbutt
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Tranquility",    () => hp < 0.7 && ! buff("Tranquility")),
+                        new AandC("Bleat",          () => hp < 0.7 ),
+                        new AandC("Headbutt"),
+                        new AandC("Hoof"),
+                        new AandC("Stampede"),
+                        new AandC("Nature's Ward"),
+                    };
+                    break;
+
+                case "Fire Beetle":
+                case "Lava Beetle":
+                    /* Abilities:
+                     * Slot 1: Burn             | Flank
+                     * Slot 2: Hiss             | Cauterize
+                     * Slot 3: Scorched Earth   | Apocalypse
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Apocalypse"),
+                        new AandC("Cauterize",      () => hp < 0.7),
+                        new AandC("Burn"),
+                        new AandC("Flank"),
+                        new AandC("Hiss"),
+                        new AandC("Scorched Earth"),
+                    };
+                    break;
+
+                case "Frostfur Rat":
+                    /* Changelog:
+                     * 2015-01-20: Sneak Attack is now checking for all blindness effects - Studio60
+                     *             Refuge is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Sneak Attack | Flurry
+                     * Slot 2: Crouch       | Refuge
+                     * Slot 3: Stampede     | Call Darkness
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Sneak Attack",   () => enemyIsBlinded()),
+                        new AandC("Crouch",         () => ! buff("Crouch")),
+                        new AandC("Refuge",         () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Stampede",       () => ! debuff("Shattered Defenses")),
+                        new AandC("Call Darkness",  () => ! weather("Darkness")),
+                        new AandC("Sneak Attack"),
+                        new AandC("Flurry"),
+                    };
+                    break;
+
+                case "Golden Pig": 
+                case "Lucky": 
+                case "Mr. Wiggles": 
+                case "Silver Pig":
+                    /* Abilities:
+                     * Slot 1: Hoof         | Diseased Bite
+                     * Slot 2: Crouch       | Buried Treasure
+                     * Slot 3: Uncanny Luck | Headbutt
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Headbutt"),
+                        new AandC("Hoof"),
+                        new AandC("Diseased Bite"),
+                        new AandC("Crouch"),
+                        new AandC("Buried Treasure"),
+                        new AandC("Uncanny Luck"),
+                    };
+                    break;
+
+                case "Grassland Hopper": 
+                case "Marsh Fiddler": 
+                case "Red Cricket": 
+                case "Singing Cricket":
+                    /* Abilities:
+                     * Slot 1: Skitter          | Screech
+                     * Slot 2: Swarm            | Cocoon Strike
+                     * Slot 3: Nature's Touch   | Inspiring Song
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Nature's Touch", () => hp < 0.7),
+                        new AandC("Skitter"),
+                        new AandC("Screech"),
+                        new AandC("Swarm"),
+                        new AandC("Cocoon Strike"),
+                        new AandC("Inspiring Song"),
+                    };
+                    break;
+
+                case "Grotto Vole":
+                case "Whiskers the Rat":
+                    /* Abilities:
+                     * Slot 1: Scratch      | Flurry
+                     * Slot 2: Sting        | Survival
+                     * Slot 3: Stampede     | Comeback
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",   () => hp < 0.3),
+                        new AandC("Scratch"),
+                        new AandC("Flurry"),
+                        new AandC("Sting"),
+                        new AandC("Stampede"),
+                        new AandC("Comeback"),
+                    };
+                    break;
+
+                case "Gu'chi Swarmling":
+                    /* Changelog:
+                     * 2015-01-20: Burrow is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Chomp        | Swarm
+                     * Slot 2: Acidic Goo   | Chew
+                     * Slot 3: Consume      | Burrow
+                     *
+                     * Tactics Information:
+                     * Burrow  used defensivey
+                     */
+                    critter_abilities = new List<AandC>() {
+                        new AandC("Burrow",     () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Swarm",      () => ! debuff("Shattered Defenses")),
+                        new AandC("Acidic Goo", () => ! debuff("Acidic Goo")),
+                        new AandC("Chew",       () => ! buff("Chew")),
+                        new AandC("Consume",    () => hp < 0.8),
+                        new AandC("Chomp"),
+                        new AandC("Swarm"),
+                    };
+                    break;
+
+                case "Highlands Skunk": 
+                case "Mountain Skunk": 
+                case "Skunk": 
+                case "Stinker":
+                    /* Abilities:
+                     * Slot 1: Scratch  | Flurry
+                     * Slot 2: Rake     | Perk Up
+                     * Slot 3: Stench   | Bleat
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Scratch"),
+                        new AandC("Flurry"),
+                        new AandC("Rake"),
+                        new AandC("Perk Up"),
+                        new AandC("Stench"),
+                        new AandC("Bleat"),
+                    };
+                    break;
+
+                case "Imperial Silkworm":
+                    /* Abilities:
+                     * Slot 1: Chomp        | Consume
+                     * Slot 2: Sticky Goo   | Moth Balls
+                     * Slot 3: Burrow       | Moth Dust
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Chomp"),
+                        new AandC("Consume"),
+                        new AandC("Sticky Goo"),
+                        new AandC("Moth Balls"),
+                        new AandC("Moth Dust"),
+                    };
+                    break;
+
+                case "Lovebird Hatchling":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Peck         | Alpha Strike
+                     * Slot 2: Lovestruck   | Hawk Eye
+                     * Slot 3: Pheromones   | Predatory Strike
+                     *
+                     * TODO: Pheromones need to check if more than active enemy pet is alive
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Lovestruck"),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Peck"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Pheromones",         () => ! debuff("Pheromones")),
+                    };
+                    break;
+
+                case "Lucky Quilen Cub":
+                case "Perky Pug":
+                    /* Abilities:
+                     * Slot 1: Bite     | Comeback
+                     * Slot 2: Perk Up  | Buried Treasure
+                     * Slot 3: Burrow   | Trample
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burrow"),
+                        new AandC("Bite"),
+                        new AandC("Comeback"),
+                        new AandC("Perk Up"),
+                        new AandC("Buried Treasure"),
+                        new AandC("Trample"),
+                    };
+                    break;
+
+                case "Malayan Quillrat": 
+                case "Malayan Quillrat Pup": 
+                case "Porcupette": 
+                case "Silent Hedgehog":
+                    /* Abilities:
+                     * Slot 1: Bite         | Poison Fang
+                     * Slot 2: Spiked Skin  | Counterstrike
+                     * Slot 3: Survival     | Powerball
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",       () =>  hp < 0.3),
+                        new AandC("Spiked Skin",    () =>  ! buff("Spiked Skin")),
+                        new AandC("Bite"),
+                        new AandC("Poison Fang"),
+                        new AandC("Counterstrike"),
+                        new AandC("Powerball"),
+                    };
+                    break;
+
+                case "Nether Roach":
+                    /* Abilities:
+                     * Slot 1: Flank    | Nether Blast
+                     * Slot 2: Hiss     | Survival
+                     * Slot 3: Swarm    | Apocalypse
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",       () => hp < 0.3),
+                        new AandC("Flank"),
+                        new AandC("Nether Blast"),
+                        new AandC("Hiss"),
+                        new AandC("Swarm"),
+                        new AandC("Apocalypse"),
+                    };
+                    break;
+
+                case "Peanut":
+                case "Pint-Sized Pink Pachyderm":
+                    /* Abilities:
+                     * Slot 1: Smash            | Trample
+                     * Slot 2: Trumpet Strike   | Survival
+                     * Slot 3: Headbutt         | Stampede 
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",           () => hp < 0.3 ),
+                        new AandC("Headbutt"),
+                        new AandC("Smash"),
+                        new AandC("Trample"),
+                        new AandC("Trumpet Strike"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Pygmy Cow":
+                    /* Changelog:
+                     * 2015-01-20: Where's the Beef? is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Stampede             | Chew
+                     * Slot 2: Mother's Milk        | Feed
+                     * Slot 3: Where's the Beef?    | Udder Destruction
+                     *
+                     * Tactics Information:
+                     * Chew: If selected, Pygmy Cow might have to pass at times
+                     * 
+                     * TODO: Mother's Milk needs to check if other own pets might need heal
+                     */
+                    critter_abilities = new List<AandC>() {
+                        new AandC("Where's the Beef?",  () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Feed",               () => hp < 0.8),
+                        new AandC("Udder Destruction"),
+                        new AandC("Stampede"),
+                        new AandC("Chew"),
+                        new AandC("Mother's Milk"),
+                    };
+                    break;
+
+                case "Rapana Whelk": 
+                case "Rusty Snail": 
+                case "Scooter the Snail": 
+                case "Shimmershell Snail": 
+                case "Silkbead Snail":
+                    /* Abilities:
+                     * Slot 1: Ooze Touch   | Absorb
+                     * Slot 2: Acidic Goo   | Shell Shield
+                     * Slot 3: Dive         | Headbutt
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Acidic Goo",     () => ! debuff("Acidic Goo")),
+                        new AandC("Shell Shield",   () => ! buff("Shell Shield")),
+                        new AandC("Headbutt"),
+                        new AandC("Dive"),
+                        new AandC("Ooze Touch"),
+                        new AandC("Absorb"),
+                    };
+                    break;
+
+                case "Wolpertinger":
+                    /* Abilities:
+                     * Slot 1: Scratch  | Horn Attack
+                     * Slot 2: Flyby    | Sleeping Gas
+                     * Slot 3: Headbutt | Rampage
+                     */
+                    critter_abilities = new List<AandC>() 
+                    {
+                        new AandC("Headbutt"),
+                        new AandC("Scratch"),
+                        new AandC("Horn Attack"),
+                        new AandC("Flyby"),
+                        new AandC("Sleeping Gas"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+ 
+                default:
+                    /////////////////////
+                    // Unknown Critter //
+                    /////////////////////
+                    Logger.Alert("Unknown critter pet: " + petName);
+                    critter_abilities = null;
+                    break;
             }
+
             return critter_abilities;
         }
     }

--- a/Prosto_Pets/Pets/Custom.cs
+++ b/Prosto_Pets/Pets/Custom.cs
@@ -23,21 +23,24 @@ namespace Prosto_Pets
 
             List<AandC> custom_abilities = null;
 
-            //////////////////
-            //// CRABS //
-            //////////////////
- 
-            if (petName == "Emperor Crab" || petName == "Shore Crab" || petName == "Shore Crawler" || petName == "Spirebound Crab" || petName == "Strand Crab" || petName == "Strand Crawler")
+            /* 
+            // EXAMPLE:
+             
+            if (petName == "Emperor Crab" || petName == "Shore Crab" || petName == "Shore Crawler" || petName == "Spirebound Crab" || petName == "Strand Crab" || petName == "Strand Crawler") {
                 custom_abilities = new List<AandC>()
-		{
-			new AandC( "Whirlpool", 		() => hpEnemy > 0.5 ),	        // Slot 3   // TODO: check if there are other enemy pets that will take a hit
-			new AandC( "Surge",             () => hpEnemy < hp	),  	    // Slot 1  -- makes it more aggressive
-			new AandC( "Renewing Mists",    () => buffLeft("Renewing Mists") < 2	),  	// Slot 2
-			new AandC( "Healing Wave", 	    () => hp < 0.7 ),	                        // Slot 2
-			new AandC( "Shell Shield", 	    () => buffLeft("Shell Shield") < 2 ),	    // Slot 3
-			new AandC( "Snap" 			),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-		};
+		        {
+			        new AandC( "Whirlpool", 		() => hpEnemy > 0.5 ),	        // Slot 3   // TODO: check if there are other enemy pets that will take a hit
+			        new AandC( "Surge",             () => hpEnemy < hp	),  	    // Slot 1  -- makes it more aggressive
+			        new AandC( "Renewing Mists",    () => buffLeft("Renewing Mists") < 2	),  	// Slot 2
+			        new AandC( "Healing Wave", 	    () => hp < 0.7 ),	                        // Slot 2
+			        new AandC( "Shell Shield", 	    () => buffLeft("Shell Shield") < 2 ),	    // Slot 3
+			        new AandC( "Snap" 			),	// Slot 1
+			        new AandC( "Surge" 			),	// Slot 1
+		        };
+            }            
+            
+            
+            */
 
             return custom_abilities;
         }

--- a/Prosto_Pets/Pets/Dragonkin.cs
+++ b/Prosto_Pets/Pets/Dragonkin.cs
@@ -1,6 +1,6 @@
-////////////////
+///////////////
 // DRAGONKIN //
-////////////////
+///////////////
 
 using System;
 using System.Collections.Generic;
@@ -24,288 +24,513 @@ namespace Prosto_Pets
 
             List<AandC> dragonkin_abilities;
 
-
-//////////////////-
-// DRAGON WHELPS //
-//////////////////-
-            if (petName == "Azure Whelpling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Arcane Storm" 	),	// Slot 2
-			new AandC( "Wild Magic" 		),	// Slot 2
-			new AandC( "Surge of Power" 	),	// Slot 3
-			new AandC( "Ice Tomb" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Crimson Whelpling" || petName == "Onyxian Whelpling" || petName == "Spawn of Onyxia")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Healing Flame",  () =>hp < 0.75 ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Scorched Earth" 	),	// Slot 2
-			new AandC( "Deep Breath" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Dark Whelpling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Roar", () => 			! buff("Attack Boost") ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Shadowflame" 	),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Call Darkness" 	),	// Slot 2
-			new AandC( "Deep Breath" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Bronze Whelpling")     // Valpsjuk
-                dragonkin_abilities = new List<AandC>()
-		{
-		new AandC( "Arcane Slash",      () => hpEnemy < 0.2 				),	// Slot 1
-		new AandC( "Arcane Storm",      () => buffLeft("Arcane Storm") < 2	),	// Slot 3
-		new AandC( "Early Advantage",   () => hpEnemy < hp					),	// Slot 2
-		new AandC( "Tail Sweep"	    										),	// Slot 1
-		new AandC( "Arcane Slash" 			                      			),	// Slot 1
-		new AandC( "Crystal Prison" 		                        		),	// Slot 2
-		};
-            else if (petName == "Emerald Proto-Whelp")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Ancient Blessing",  () => buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Emerald Bite" 	),	// Slot 1
-			new AandC( "Emerald Presence"),	// Slot 2
-			new AandC( "Proto-Strike" 	),	// Slot 3
-			new AandC( "Emerald Dream" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Emerald Whelpling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Moonfire", () => 		! weather("Moonlight") ),	// Slot 2
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Emerald Bite" 	),	// Slot 1
-			new AandC( "Emerald Presence"),	// Slot 2
-			new AandC( "Tranquility" 	),	// Slot 3
-			new AandC( "Emerald Dream" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Infinite Whelpling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Healing Flame",  () =>hp < 0.75 ),	// Slot 2
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Sleeping Gas" 	),	// Slot 1
-			new AandC( "Weakness" 		),	// Slot 2
-			new AandC( "Early Advantage" ),	// Slot 3
-			new AandC( "Darkflame" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Lil' Deathwing")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Shadowflame" 	),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Call Darkness" 	),	// Slot 2
-			new AandC( "Roll" 			),	// Slot 2
-			new AandC( "Elementium Bolt" ),	// Slot 3
-			new AandC( "Cataclysm" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Lil' Tarecgosa")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Surge of Power" 	),	// Slot 2
-			new AandC( "Wild Magic" 		),	// Slot 2
-			new AandC( "Arcane Storm" 	),	// Slot 3
-			new AandC( "Arcane Explosion"),	// Slot 3
-		}
-            ;
-            else if (petName == "Nether Faerie Dragon")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Moonfire", () => 		! weather("Moonlight") ),	// Slot 3
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Evanescence" 	),	// Slot 2
-			new AandC( "Life Exchange" 	),	// Slot 2
-		}
-            ;
-            else if (petName == "Netherwhelp")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Nether Blast" 	),	// Slot 1
-			new AandC( "Phase Shift" 	),	// Slot 2
-			new AandC( "Accuracy" 		),	// Slot 2
-			new AandC( "Instability" 	),	// Slot 3
-			new AandC( "Soulrush" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Nexus Whelpling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Arcane Storm", ()=> !weather("Arcane Storm") 	),	// Slot 3
-			new AandC( "Mana Surge" 		),	// Slot 2
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Frost Breath" 	),	// Slot 1
-			new AandC( "Sear Magic" 		),	// Slot 2
-			new AandC( "Wild Magic" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Proto-Drake Whelp")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Ancient Blessing",  () => buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Roar", () => 			! buff("Attack Boost") ),	// Slot 3
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Flamethrower" 	),	// Slot 2
-			new AandC( "Proto-Strike" 	),	// Slot 3
-		}
-                    ////////////////-
-                    // DRAGONHAWKS //
-                    ////////////////-
-            ;
-            else if (petName == "Blue Dragonhawk Hatchling" || petName == "Golden Dragonhawk Hatchling" || petName == "Red Dragonhawk Hatchling" || petName == "Silver Dragonhawk Hatchling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Quills" 			),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 2
-			new AandC( "Conflagrate" 	),	// Slot 2
-			new AandC( "Flame Breath" 	),	// Slot 3
-			new AandC( "Flamethrower" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Phoenix Hawk Hatchling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Quills" 			),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 2
-			new AandC( "Flyby" 			),	// Slot 2
-			new AandC( "Flame Breath" 	),	// Slot 3
-		}
-                    //////////////
-                    // SERPENTS //
-                    //////////////
-            ;
-            else if (petName == "Celestial Dragon")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Moonfire", () => 		! weather("Moonlight") ),	// Slot 3
-			new AandC( "Starfall", () => 		! weather("Moonlight") ),	// Slot 3
-			new AandC( "Ancient Blessing",  () => buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Roar", () => 			! buff("Attack Boost") ),	// Slot 1
-			new AandC( "Flamethrower" 	),	// Slot 1
-			new AandC( "Arcane Storm" 	),	// Slot 2 // Can it remove a root if( already rooted || only prevent future roots cast against you?
-		}
-            ;
-            else if (petName == "Essence of Competition" || petName == "Spirit of Competition")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Ancient Blessing",  () => buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Competitive Spirit"),	// Slot 2
-			new AandC( "Flamethrower" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Soul of the Aspects" || petName == "Spirit of Competition")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Sunlight" 		),	// Slot 2
-			new AandC( "Deflection" 		),	// Slot 2
-			new AandC( "Surge of Light" 	),	// Slot 3
-			new AandC( "Solar Beam" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Thundering Serpent Hatchling" || petName == "Tiny Green Dragon" || petName == "Tiny Red Dragon" || petName == "Wild Golden Hatchling" || petName == "Wild Jade Hatchling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Roar", () => 			! buff("Attack Boost") ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Call Lightning" 	),	// Slot 2
-		}
-            ;
-            else if (petName == "Wild Crimson Hatchling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Healing Flame",  () =>hp < 0.75 ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Scorched Earth" 	),	// Slot 2
-			new AandC( "Deep Breath" 	),	// Slot 3
-		}
-                    //////////////////-
-                    // MISCELLANEOUS //
-                    //////////////////-
-            ;
-            else if (petName == "Chrominius")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Ancient Blessing",  () => !buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Howl" 			),	// Slot 2
-			new AandC( "Surge of Power" 	),	// Slot 3
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Arcane Explosion"),	// Slot 1
-			new AandC( "Ravage" 			),	// Slot 3
-		}
-            ;
-            else if (petName == "Death Talon Whelpguard")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Blitz" 			),	// Slot 1
-			new AandC( "Shadowflame" 	),	// Slot 1
-			new AandC( "Whirlwind" 		),	// Slot 2
-			new AandC( "Spiked Skin" 	),	// Slot 2
-			new AandC( "Darkflame" 		),	// Slot 3
-			new AandC( "Clobber" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Sprite Darter Hatchling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Moonfire", () => 		! weather("Moonlight") ),	// Slot 3
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Evanescence" 	),	// Slot 2
-			new AandC( "Life Exchange" 	),	// Slot 2
-		}
-            ;
-            else if (petName == "Untamed Hatchling")
-                dragonkin_abilities = new List<AandC>() 
-		{
-			new AandC( "Healing Flame",  () =>  hp < 0.75 ),	// Slot 3
-			new AandC( "Roar", () => 			! buff("Attack Boost") ),	// Slot 2
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Spiked Skin" 	),	// Slot 2
-			new AandC( "Instability" 	),	// Slot 3
-		};
-            //////////////////-
-
-            else // Unknown pet
+            switch (petName)
             {
-                Logger.Alert("Unknown dragonkin pet: " + petName);
-                return null;
+
+                case "Albino Chimaeraling":
+                    /* Changelog:
+                     * 2015-01-20: Lift-Off has had its defensive priority increased - Studio60
+                     *             Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Shadowflame  | Tail Sweep
+                     * Slot 2: Roar         | Call Darkness
+                     * Slot 3: Lift-Off     | Deep Breath
+                     * 
+                     * Tactic Information:
+                     * Deep Breath does more dmg vs magic, but magic-pets can't receive more dmg than 35% of their hp
+                     * Deep Breath tends to miss... 
+                     */
+                    dragonkin_abilities = new List<AandC>() {
+                        new AandC("Lift-Off",       () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Roar",           () => ! buff("Attack Boost")),
+                        new AandC("Call Darkness",  () => ! weather("Darkness")),
+                        new AandC("Lift-Off",       () => strong("Lift-Off")),
+                        new AandC("Shadowflame"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Deep Breath"),
+                    };
+                    break;
+
+                case "Azure Whelpling":
+                    /* Abilities:
+                     * Slot 1: Claw             | Breath
+                     * Slot 2: Arcane Storm     | Wild Magic
+                     * Slot 3: Surge of Power   | Ice Tomb
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Breath"),
+                        new AandC("Arcane Storm"),
+                        new AandC("Wild Magic"),
+                        new AandC("Surge of Power"),
+                        new AandC("Ice Tomb"),
+                    };
+                    break;
+
+                case "Blue Dragonhawk Hatchling":
+                case "Golden Dragonhawk Hatchling": 
+                case "Red Dragonhawk Hatchling": 
+                case "Silver Dragonhawk Hatchling":
+                    /* Abilities:
+                     * Slot 1: Claw         | Quills
+                     * Slot 2: Rake         | Conflagrate
+                     * Slot 3: Flame Breath | Flamethrower
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Quills"),
+                        new AandC("Rake"),
+                        new AandC("Conflagrate"),
+                        new AandC("Flame Breath"),
+                        new AandC("Flamethrower"),
+                    };
+                    break;
+
+                case "Bronze Whelpling":
+                    /* Change Log:
+                     * 2015-01-15: Initial design by Valpsjuk
+                     * 
+                     * Abilities:
+                     * Slot 1: Arcane Slash     | Tail Sweep
+                     * Slot 2: Early Advantage  | Crystal Prison
+                     * Slot 3: Lift-Off         | Arcane Storm
+                     */
+                    dragonkin_abilities = new List<AandC>()
+                    {
+                        new AandC("Arcane Slash",       () => hpEnemy < 0.2),
+                        new AandC("Arcane Storm",       () => buffLeft("Arcane Storm") < 2),
+                        new AandC("Early Advantage",    () => hpEnemy < hp),
+                        new AandC("Tail Sweep"),
+                        new AandC("Arcane Slash"),
+                        new AandC("Crystal Prison"),
+                    };
+                    break;
+
+                case "Celestial Dragon":
+                    /* Abilities:
+                     * Slot 1: Flamethrower     | Roar 
+                     * Slot 2: Ancient Blessing | Arcane Storm
+                     * Slot 3: Moonfire         | Starfall
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Moonfire",           () => ! weather("Moonlight")),
+                        new AandC("Starfall",           () => ! weather("Moonlight")),
+                        new AandC("Ancient Blessing",   () => buff("Ancient Blessing") || hp < 0.75),
+                        new AandC("Roar",               () => ! buff("Attack Boost")),
+                        new AandC("Flamethrower"),
+                        new AandC("Arcane Storm"),
+                    };
+                    break;
+
+                case "Chrominius":
+                    /* Abilities:
+                     * Slot 1: Bite     | Arcane Explosion
+                     * Slot 2: Howl     | Ancient Blessing
+                     * Slot 3: Ravage   | Surge of Power
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ancient Blessing",   () => !buff("Ancient Blessing") || hp < 0.75 ),
+                        new AandC("Howl"),
+                        new AandC("Surge of Power"),
+                        new AandC("Bite"),
+                        new AandC("Arcane Explosion"),
+                        new AandC("Ravage"),
+                    };
+                    break;
+
+                case "Crimson Whelpling": 
+                case "Onyxian Whelpling": 
+                case "Spawn of Onyxia":
+                    /* Abilities:
+                     * Slot 1: Breath           | Tail Sweep
+                     * Slot 2: Healing Flame    | Scorched Earth
+                     * Slot 3: Lift-Off         | Deep Breath
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Healing Flame",      () => hp < 0.75),
+                        new AandC("Lift-Off"),
+                        new AandC("Breath"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Scorched Earth"),
+                        new AandC("Deep Breath"),
+                    };
+                    break;
+
+                case "Dark Whelpling":
+                    /* Abilities:
+                     * Slot 1: Shadowflame  | Tail Sweep
+                     * Slot 2: Roar         | Call Darkness
+                     * Slot 3: Lift-Off     | Deep Breath
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Roar",           () => ! buff("Attack Boost")),
+                        new AandC("Lift-Off"),
+                        new AandC("Shadowflame"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Call Darkness"),
+                        new AandC("Deep Breath"),
+                    };
+                    break;
+
+                case "Death Talon Whelpguard":
+                    /* Abilities:
+                     * Slot 1: Blitz        | Shadowflame
+                     * Slot 2: Whirlwind    | Spiked Skin
+                     * Slot 3: Darkflame    | Clobber
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Blitz"),
+                        new AandC("Shadowflame"),
+                        new AandC("Whirlwind"),
+                        new AandC("Spiked Skin"),
+                        new AandC("Darkflame"),
+                        new AandC("Clobber"),
+                    };
+                    break;
+
+                case "Emerald Proto-Whelp":
+                    /* Abilities:
+                     * Slot 1: Breath           | Emerald Bite
+                     * Slot 2: Ancient Blessing | Emerald Presence 
+                     * Slot 3: Proto-Strike     | Emerald Dream
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ancient Blessing",   () => buff("Ancient Blessing") || hp < 0.75),
+                        new AandC("Breath"),
+                        new AandC("Emerald Bite"),
+                        new AandC("Emerald Presence"),
+                        new AandC("Proto-Strike"),
+                        new AandC("Emerald Dream"),
+                    };
+                    break;
+
+                case "Essence of Competition":
+                case "Spirit of Competition":
+                    /* Abilities:
+                     * Slot 1: Breath           | Tail Sweep
+                     * Slot 2: Ancient Blessing | Competitive Spirit
+                     * Slot 3: Lift-Off         | Flamethrower
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ancient Blessing",       () => buff("Ancient Blessing") || hp < 0.75),
+                        new AandC("Lift-Off"),
+                        new AandC("Breath"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Competitive Spirit"),
+                        new AandC("Flamethrower"),
+                    };
+                    break;
+
+                case "Emerald Whelpling":
+                    /* Abilities:
+                     * Slot 1: Breath       | Emerald Bite
+                     * Slot 2: Moonfire     | Emerald Presence
+                     * Slot 3: Tranquility  | Emerald Dream
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Moonfire",           () => ! weather("Moonlight")),
+                        new AandC("Breath"),
+                        new AandC("Emerald Bite"),
+                        new AandC("Emerald Presence"),
+                        new AandC("Tranquility"),
+                        new AandC("Emerald Dream"),
+                    };
+                    break;
+
+                case "Infinite Whelpling":
+                    /* Abilities:
+                     * Slot 1: Tail Sweep       | Sleeping Gas
+                     * Slot 2: Healing Flame    | Weakness
+                     * Slot 3: Early Advantage  | Darkflame
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Healing Flame",      () => hp < 0.75),
+                        new AandC("Tail Sweep"),
+                        new AandC("Sleeping Gas"),
+                        new AandC("Weakness"),
+                        new AandC("Early Advantage"),
+                        new AandC("Darkflame"),
+                    };
+                    break;
+
+                case "Lanticore Spawnling":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Triple Snap      | Sleeping Gas
+                     * Slot 2: Cataclysm        | Corrosion
+                     * Slot 3: Ancient Blessing | Devour
+                     * 
+                     * Tactics Information:
+                     * Cataclysm's hit chance makes it too unreliable without other hit chance buff
+                     * Devour can be used earlier against critters
+                     */
+                    dragonkin_abilities = new List<AandC>() {
+                        new AandC("Devour",             () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Ancient Blessing",   () => hp < 0.8 && ! buff("Ancient Blessing")),
+                        new AandC("Corrosion",          () => ! debuff("Corrosion")),
+                        new AandC("Triple Snap"),
+                        new AandC("Sleeping Gas"),
+                        new AandC("Cataclysm"),
+                    };
+                    break;
+
+                case "Lil' Deathwing":
+                    /* Abilities:
+                     * Slot 1: Shadowflame      | Tail Sweep
+                     * Slot 2: Call Darkness    | Roll
+                     * Slot 3: Elementium Bolt  | Cataclysm
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shadowflame"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Call Darkness"),
+                        new AandC("Roll"),
+                        new AandC("Elementium Bolt"),
+                        new AandC("Cataclysm"),
+                    };
+                    break;
+
+                case "Lil' Tarecgosa":
+                    /* Abilities:
+                     * Slot 1: Breath           | Arcane Blast
+                     * Slot 2: Surge of Power   | Wild Magic
+                     * Slot 3: Arcane Storm     | Arcane Explosion
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Breath"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Surge of Power"),
+                        new AandC("Wild Magic"),
+                        new AandC("Arcane Storm"),
+                        new AandC("Arcane Explosion"),
+                    };
+                    break;    
+
+                case "Nether Faerie Dragon":
+                    /* Abilities:
+                     * Slot 1: Slicing Wind | Arcane Blast
+                     * Slot 2: Evanescence  | Life Exchange
+                     * Slot 3: Moonfire     | Cyclone
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Moonfire",       () => ! weather("Moonlight")),
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Evanescence"),
+                        new AandC("Life Exchange"),
+                    };
+                    break;
+
+                case "Netherwhelp":
+                    /* Abilities:
+                     * Slot 1: Breath       | Nether Blast
+                     * Slot 2: Phase Shift  | Accuracy
+                     * Slot 3: Instability  | Soulrush
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Breath"),
+                        new AandC("Nether Blast"),
+                        new AandC("Phase Shift"),
+                        new AandC("Accuracy"),
+                        new AandC("Instability"),
+                        new AandC("Soulrush"),
+                    };
+                    break;
+
+                case "Nexus Whelpling":
+                    /* Abilities:
+                     * Slot 1: Tail Sweep | Frost Breath
+                     * Slot 2: Sear Magic | Mana Surge
+                     * Slot 3: Wild Magic | Arcane Storm
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Arcane Storm", ()=> ! weather("Arcane Storm")),
+                        new AandC("Mana Surge"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Frost Breath"),
+                        new AandC("Sear Magic"),
+                        new AandC("Wild Magic"),
+                    };
+                    break;
+
+                case "Proto-Drake Whelp":
+                    /* Abilities:
+                     * Slot 1: Breath       | Bite
+                     * Slot 2: Flamethrower | Ancient Blessing
+                     * Slot 3: Proto-Strike | Roar
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ancient Blessing",   () => buff("Ancient Blessing") || hp < 0.75),
+                        new AandC("Roar",               () => ! buff("Attack Boost") ),
+                        new AandC("Breath"),
+                        new AandC("Bite"),
+                        new AandC("Flamethrower"),
+                        new AandC("Proto-Strike"),
+                    };
+                    break;
+
+                case "Phoenix Hawk Hatchling":
+                    /* Abilities:
+                     * Slot 1: Claw         | Quills
+                     * Slot 2: Rake         | Flyby
+                     * Slot 3: Flame Breath | Lift-Off
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lift-Off"),
+                        new AandC("Claw"),
+                        new AandC("Quills"),
+                        new AandC("Rake"),
+                        new AandC("Flyby"),
+                        new AandC("Flame Breath"),
+                    };
+                    break;
+
+                case "Sprite Darter Hatchling":
+                    /* Abilities:
+                     * Slot 1: Slicing Wind | Arcane Blast
+                     * Slot 2: Evanescence  | Life Exchange
+                     * Slot 3: Moonfire     | Cyclone
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Moonfire",       () => ! weather("Moonlight")),
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Evanescence"),
+                        new AandC("Life Exchange"),
+                    };
+                    break;
+
+                case "Soul of the Aspects":
+                    /* Abilities:
+                     * Slot 1: Claw             | Breath
+                     * Slot 2: Sunlight         | Deflection
+                     * Slot 3: Surge of Light   | Solar Beam
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Breath"),
+                        new AandC("Sunlight"),
+                        new AandC("Deflection"),
+                        new AandC("Surge of Light"),
+                        new AandC("Solar Beam"),
+                    };
+                    break;
+
+                case "Thundering Serpent Hatchling": 
+                case "Tiny Green Dragon": 
+                case "Tiny Red Dragon": 
+                case "Wild Golden Hatchling": 
+                case "Wild Jade Hatchling":
+                    /* Abilities:
+                     * Slot 1: Breath           | Tail Sweep
+                     * Slot 2: Call Lightning   | Roar
+                     * Slot 3: Cyclone          | Lift-OFf
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Roar",               () => ! buff("Attack Boost")),
+                        new AandC("Lift-Off"),
+                        new AandC("Breath"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Call Lightning"),
+                    };
+                    break;
+
+                case "Untamed Hatchling":
+                    /* Abilities:
+                     * Slot 1: Claw         | Tail Sweep
+                     * Slot 2: Roar         | Spiked Skin
+                     * Slot 3: Instability  | Healing Flame
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Healing Flame",  () => hp < 0.75),
+                        new AandC("Roar",           () => ! buff("Attack Boost")),
+                        new AandC("Claw"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Spiked Skin"),
+                        new AandC("Instability"),
+                    };
+                    break;
+
+                case "Wild Crimson Hatchling":
+                    /* Abilities:
+                     * Slot 1: Breath           | Tail Sweep
+                     * Slot 2: Healing Flame    | Scorched Earth
+                     * Slot 3: Lift-Off         | Deep Breath
+                     */
+                    dragonkin_abilities = new List<AandC>() 
+                    {
+                        new AandC("Healing Flame",  () => hp < 0.75),
+                        new AandC("Lift-Off"),
+                        new AandC("Breath"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Scorched Earth"),
+                        new AandC("Deep Breath"),
+                    };
+                    break;
+
+                case "Yu'la, Broodling of Yu'lon":
+                    /* Changelog:
+                     * 2015-01-20: Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities:
+                     * Slot 1: Breath           | Jadefire Lightning
+                     * Slot 2: Emerald Presence | Celestial Blessing
+                     * Slot 3: Lift-Off         | Life Exchange
+                     * 
+                     * TODO: Clestial Blessing does only make sense with another pet and immediate swapout
+                     * TODO: Life Exchange needs absolute hp values to be used right, might mess things up on ringer-pets otherwise
+                     * TODO: Lift-Off should be used aggressively if the enemy has no shouldIHide-attacks
+                     */
+                    dragonkin_abilities = new List<AandC>() {
+                        new AandC("Emerald Presence",       () => ! buff("Emerald Presence")),
+                        new AandC("Lift-Off",               () => strong("Lift-Off")),
+                        new AandC("Lift-Off",               () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Breath"),
+                        new AandC("Jadefire Lightning"),
+                        new AandC("Celestial Blessing"),
+                        new AandC("Life Exchange"),
+                    };
+                    break;
+            
+                default: 
+                    ///////////////////////////
+                    // Unknown Dragonkin Pet //
+                    ///////////////////////////
+                    Logger.Alert("Unknown dragonkin pet: " + petName);
+                    dragonkin_abilities = null;
+                    break;
             }
+
             return dragonkin_abilities;
         }
     }

--- a/Prosto_Pets/Pets/Elemental.cs
+++ b/Prosto_Pets/Pets/Elemental.cs
@@ -25,413 +25,1049 @@ namespace Prosto_Pets
 
             List<AandC> elemental_abilities;
 
-
-
-////////////////
-// ELEMENTALS //
-////////////////
-if( petName == "Fel Flame" || petName == "Searing Scorchling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Scorched Earth",  () =>  ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Conflagrate", () => 	debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Immolation", () => 		! buff("Immolation") ),	// Slot 3
-			new AandC( "Immolate", () => 		! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Flame Breath" 	),	// Slot 1
-		}
-;else if(petName == "Frigid Frostling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Frost Shock" 	),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 1
-			new AandC( "Frost Nova" 		),	// Slot 2
-			new AandC( "Slippery Ice" 	),	// Slot 2
-			new AandC( "Ice Tomb" 		),	// Slot 3
-			new AandC( "Howling Blast" 	),	// Slot 3
-		}
-;else if(petName == "Grinder" || petName == "Lumpy" || petName == "Pebble" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Stone Shot" 		),	// Slot 1
-			new AandC( "Stone Rush" 		),	// Slot 1
-			new AandC( "Sandstorm" 		),	// Slot 2
-			new AandC( "Rupture" 		),	// Slot 2
-			new AandC( "Rock Barrage" 	),	// Slot 3
-			new AandC( "Quake" 			),	// Slot 3
-		}
-;else if(petName == "Kirin Tor Familiar" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Beam" 			),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Gravity" 		),	// Slot 2
-			new AandC( "Arcane Storm" 	),	// Slot 2
-			new AandC( "Arcane Explosion"),	// Slot 3
-			new AandC( "Dark Simulacrum" ),	// Slot 3
-		}
-;else if(petName == "Living Sandling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Sand Bolt" 		),	// Slot 1
-			new AandC( "Stoneskin" 		),	// Slot 2
-			new AandC( "Sandstorm" 		),	// Slot 2
-			new AandC( "Stone Rush" 		),	// Slot 3
-			new AandC( "Quicksand" 		),	// Slot 3
-		}
-;else if(petName == "Pandaren Air Spirit" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Wild Winds" 		),	// Slot 1
-			new AandC( "Whirlwind" 		),	// Slot 2
-			new AandC( "Soothing Mists" 	),	// Slot 2
-			new AandC( "Arcane Storm" 	),	// Slot 3
-		}
-;else if(petName == "Pandaren Earth Spirit" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Stone Shot" 		),	// Slot 1
-			new AandC( "Stone Rush" 		),	// Slot 1
-			new AandC( "Rupture" 		),	// Slot 2
-			new AandC( "Rock Barrage" 	),	// Slot 2
-			new AandC( "Crystal Prison" 	),	// Slot 3
-			new AandC( "Mudslide"	 	),	// Slot 3
-		}
-;else if(petName == "Pandaren Fire Spirit" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Cauterize", () => 		hp < 0.7 ),	// Slot 3
-			new AandC( "Immolate", () => 		! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Magma Wave" 		),	// Slot 1
-			new AandC( "Flamethrower" 	),	// Slot 2
-			new AandC( "Conflagrate"	 	),	// Slot 3
-		}
-;else if(petName == "Pandaren Water Spirit" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Dive" 			),	// Slot 3
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Tidal Wave" 		),	// Slot 1
-			new AandC( "Healing Wave" 	),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 2
-			new AandC( "Geyser"	 		),	// Slot 3
-		}
-;else if(petName == "Thundertail Flapper" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Tail Slap" 		),	// Slot 1
-			new AandC( "Jolt" 			),	// Slot 1
-			new AandC( "Buried Treasure" ),	// Slot 2
-			new AandC( "Lightning Shield"),	// Slot 2
-			new AandC( "Thunderbolt" 	),	// Slot 3
-			new AandC( "Beaver Dam"		),	// Slot 3
-		}
-;else if(petName == "Tiny Twister" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Wild Winds" 		),	// Slot 1
-			new AandC( "Flyby" 			),	// Slot 2
-			new AandC( "Bash" 			),	// Slot 2
-			new AandC( "Sandstorm"		),	// Slot 3
-		}
-;else if(petName == "Water Waveling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Ice Lance" 		),	// Slot 1
-			new AandC( "Frost Nova" 		),	// Slot 2
-			new AandC( "Frost Shock" 	),	// Slot 2
-			new AandC( "Geyser" 			),	// Slot 3
-			new AandC( "Tidal Wave"		),	// Slot 3
-		}
-;else if(petName == "Tainted Waveling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Acidic Goo",  () =>	! debuff("Acidic Goo") ),	// Slot 2
-			new AandC( "Ooze Touch" 		),	// Slot 1
-			new AandC( "Poison Spit" 	),	// Slot 1
-			new AandC( "Corrosion"		),	// Slot 2
-			new AandC( "Healing Wave" 	),	// Slot 3
-			new AandC( "Creeping Ooze"	),	// Slot 3
-		}
-////////////
-// GEODES //
-////////////
-;else if(petName == "Ashstone Core" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Crystal Overload",  () => buff("Crystal Overload") && hp > 0.50 ),	// Slot 2
-			new AandC( "Feedback" 		),	// Slot 1
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Stoneskin" 		),	// Slot 2
-			new AandC( "Crystal Prison" 	),	// Slot 3
-			new AandC( "Instability" 	),	// Slot 3
-		}
-;else if(petName == "Crimson Geode" || petName == "Elementium Geode" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Crystal Overload",  () => buff("Crystal Overload") && hp > 0.50 ),	// Slot 2
-			new AandC( "Feedback" 		),	// Slot 1
-			new AandC( "Spark" 			),	// Slot 1
-			new AandC( "Amplify Magic" 	),	// Slot 2
-			new AandC( "Stone Rush" 		),	// Slot 3
-			new AandC( "Elementium Bolt" ),	// Slot 3
-		}
-//////////////
-// MYTHICAL //
-//////////////
-;else if(petName == "Core Hound Pup" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Howl" 			),	// Slot 2
-			new AandC( "Dodge" 			),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 3
-			new AandC( "Burrow" 			),	// Slot 3
-		}
-;else if(petName == "Dark Phoenix Hatchling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Conflagrate", () => 	debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Immolate", () => 		! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Darkflame" 		),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Laser" 			),	// Slot 1
-			new AandC( "Dark Rebirth" 	),	// Slot 3
-		}
-;else if(petName == "Lil' Ragnaros" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Conflagrate", () => 	debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Flamethrower", () => 	! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Sons of the Flame"),	// Slot 3
-			new AandC( "Magma Trap" 		),	// Slot 2
-			new AandC( "Sulfuras Smash" 	),	// Slot 1
-			new AandC( "Magma Wave" 		),	// Slot 1
-		}
-;else if(petName == "Phoenix Hatchling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Cauterize", () => 		hp < 0.7 ),	// Slot 2
-			new AandC( "Immolation", () => 		! buff("Immolation") ),	// Slot 3
-			new AandC( "Immolate", () => 		! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Conflagrate", () => 	debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Peck" 			),	// Slot 1
-		}
-////////////////
-// PLANT LIFE //
-////////////////
-;else if(petName == "Ammen Vale Lashling" || petName == "Crimson Lasher" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Lash" 			),	// Slot 1
-			new AandC( "Poison Lash" 	),	// Slot 1
-			new AandC( "Soothing Mists" 	),	// Slot 2
-			new AandC( "Plant" 			),	// Slot 2
-			new AandC( "Stun Seed" 		),	// Slot 3
-			new AandC( "Entangling Roots"),	// Slot 3
-		}
-;else if(petName == "Ruby Sapling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Photosynthesis", () => 	! buff("Photosynthesis") && hp < 0.8 ),	// Slot 3
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Poisoned Branch" ),	// Slot 1
-			new AandC( "Thorns" 			),	// Slot 2
-			new AandC( "Entangling Roots"),	// Slot 3
-		}
-;else if(petName == "Singing Sunflower" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Photosynthesis", () => 	! buff("Photosynthesis") && hp < 0.8 ),	// Slot 2
-			new AandC( "Early Advantage",() =>  hp < hpEnemy ),	// Slot 3
-			new AandC( "Lash" 			),	// Slot 1
-			new AandC( "Solar Beam" 		),	// Slot 1
-			new AandC( "Inspiring Song" 	),	// Slot 2
-			new AandC( "Sunlight" 		),	// Slot 3
-		}
-;else if(petName == "Sinister Squashling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Poison Lash" 	),	// Slot 1
-			new AandC( "Thorns" 			),	// Slot 2
-			new AandC( "Stun Seed" 		),	// Slot 2
-			new AandC( "Plant" 			),	// Slot 3
-			new AandC( "Leech Seed" 		),	// Slot 3
-		}
-;else if(petName == "Teldrassil Sproutling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Photosynthesis", () => 	! buff("Photosynthesis") && hp < 0.8 ),	// Slot 2
-			new AandC( "Shell Shield",   () =>  ! buff("Shell Shield") ),	// Slot 1
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Poisoned Branch" ),	// Slot 2
-			new AandC( "Thorns" 			),	// Slot 3
-			new AandC( "Entangling Roots"),	// Slot 3
-		}
-;else if(petName == "Terrible Turnip" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Weakening Blow", () =>	hpEnemy > 0.05 ),	// Slot 1 // Can! reduce enemy below 1 hp
-			new AandC( "Tidal Wave" 		),	// Slot 1
-			new AandC( "Leech Seed" 		),	// Slot 2
-			new AandC( "Inspiring Song" 	),	// Slot 2
-			new AandC( "Sunlight" 		),	// Slot 3
-			new AandC( "Sons of the Root"),	// Slot 3
-		}
-;else if(petName == "Tiny Bog Beast" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Leap", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Crush" 			),	// Slot 1
-			new AandC( "Clobber" 		),	// Slot 1
-			new AandC( "Lash" 			),	// Slot 2
-			new AandC( "Poison Lash" 	),	// Slot 3
-			new AandC( "Rampage" 		),	// Slot 3
-		}
-;else if(petName == "Venus" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Lash" 			),	// Slot 1
-			new AandC( "Poison Lash" 	),	// Slot 1
-			new AandC( "Sunlight" 		),	// Slot 2
-			new AandC( "Plant" 			),	// Slot 2
-			new AandC( "Stun Seed" 		),	// Slot 3
-			new AandC( "Leech Seed" 		),	// Slot 3
-		}
-;else if(petName == "Withers" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Photosynthesis", () => 	! buff("Photosynthesis") && hp < 0.8 ),	// Slot 2
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 1
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Poisoned Branch" ),	// Slot 2
-			new AandC( "Thorns" 			),	// Slot 3
-			new AandC( "Entangling Roots"),	// Slot 3
-		}
-;else if(petName == "Blossoming Ancient" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Photosynthesis", () =>	! buff("Photosynthesis") && hp < 0.8 ),	// Slot 2
-			new AandC( "Poisoned Branch"	),	// Slot 1
-			new AandC( "Ironbark" 		),	// Slot 1
-			new AandC( "Autumn Breeze" 	),	// Slot 2
-			new AandC( "Stun Seed" 		),	// Slot 3
-			new AandC( "Sunlight"		),	// Slot 3
-		}
-//////////////////-
-// SHALE SPIDERS //
-//////////////////-
-;else if(petName == "Amethyst Shale Hatchling" || petName == "Crimson Shale Hatchling" || petName == "Emerald Shale Hatchling" || petName == "Tiny Shale Spider" || petName == "Topaz Shale Hatchling" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Leech Life" 		),	// Slot 1
-			new AandC( "Sticky Web" 		),	// Slot 2
-			new AandC( "Poison Spit" 	),	// Slot 2
-			new AandC( "Stone Rush" 		),	// Slot 3
-			new AandC( "Stoneskin" 		),	// Slot 3
-		}
-//////////////////-
-// MISCELLANEOUS //
-//////////////////-
-;else if(petName == "Cinder Kitten" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Scorched Earth",  () =>  ! weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Immolate", () => 		! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Leap", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2 // if( your (1) speed is slower than you enemy (2) && ! boosted
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Rend" 			),	// Slot 1
-			new AandC( "Prowl" 			),	// Slot 3
-		}
-;else if(petName == "Electrified Razortooth" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Devour", () => 			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC( "Rip" 			),	// Slot 1
-			new AandC( "Jolt" 			),	// Slot 1
-			new AandC( "Paralyzing Shock"),	// Slot 2
-			new AandC( "Lightning Shield"),	// Slot 2
-			new AandC( "Blood in the Water"),	// Slot 3
-		}
-;else if(petName == "Jade Tentacle" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Photosynthesis", () => 	! buff("Photosynthesis") && hp < 0.8 ),	// Slot 2
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Poisoned Branch" ),	// Slot 1
-			new AandC( "Entangling Roots"),	// Slot 3
-			new AandC( "Thorns" 			),	// Slot 3
-		}
-;else if(petName == "Lava Crab" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Survival", () => 		hp < 0.3 ),	// Slot 1
-			new AandC( "Cauterize", () => 		hp < 0.7 ),	// Slot 2
-			new AandC( "Shell Shield",  () =>  ! buff("Shell Shield") ),	// Slot 2
-			new AandC( "Conflagrate" 	),	// Slot 3
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Magma Wave" 		),	// Slot 3
-		}
-;else if(petName == "Sapphire Cub" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Lash" 			),	// Slot 1
-			new AandC( "Pounch" 			),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 2
-			new AandC( "Screech" 		),	// Slot 2
-			new AandC( "Stone Rush" 		),	// Slot 3
-			new AandC( "Prowl" 			),	// Slot 3
-		}
-;else if(petName == "Spirit of Summer" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Scorched Earth",  () =>  ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Immolation", () => 		! buff("Immolation") ),	// Slot 3
-			new AandC( "Immolate", () => 		! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),	// Slot 2
-			new AandC( "Conflagrate", () => 	debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Flame Breath" 	),	// Slot 1
-		}
-;else if(petName == "Tiny Snowman" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Snowball" 		),	// Slot 1
-			new AandC( "Magic Hat" 		),	// Slot 1
-			new AandC( "Call Blizzard" 	),	// Slot 2
-			new AandC( "Frost Nova" 		),	// Slot 2
-			new AandC( "Howling Blast" 	),	// Slot 3
-			new AandC( "Deep Freeze" 	),	// Slot 3
-		}
-;else if(petName == "Molten Corgi" )
-	elemental_abilities = new List<AandC>() 
-		{
-			new AandC( "Puppies of the Flame", ()=> shouldIHide ),	// Slot 3
-			new AandC( "Cauterize", ()=> hp<0.7 		),	// Slot 2
-			new AandC( "Superbark" 	),	// Slot 2
-			new AandC( "Bark" 		),	// Slot 1
-			new AandC( "Flamethrower" 		),	// Slot 1
-			new AandC( "Inferno Herding" 	),	// Slot 3    // TODO NOW: define enemy lowest hp
-		};
-//////////////////-
-
-            else // Unknown pet
+            switch (petName)
             {
-                Logger.Alert("Unknown elemental pet: " + petName);
-                return null;
+                case "Amethyst Shale Hatchling":
+                case "Crimson Shale Hatchling":
+                case "Emerald Shale Hatchling":
+                case "Tiny Shale Spider":
+                case "Topaz Shale Hatchling":
+                    /* Abilities
+                     * Slot 1: Burn         | Leech Life
+                     * Slot 2: Sticky Web   | Poison Spit
+                     * Slot 3: Stone Rush   | Stoneskin
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burn"),
+                        new AandC("Leech Life"),
+                        new AandC("Sticky Web"),
+                        new AandC("Poison Spit"),
+                        new AandC("Stone Rush"),
+                        new AandC("Stoneskin"),
+                    };
+                    break;
+
+                case "Ammen Vale Lashling":
+                case "Crimson Lasher":
+                    /* Abilities
+                     * Slot 1: Lash             | Poison Lash
+                     * Slot 2: Soothing Mists   | Plant
+                     * Slot 3: Stun Seed        | Entangling Roots
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lash"),
+                        new AandC("Poison Lash"),
+                        new AandC("Soothing Mists"),
+                        new AandC("Plant"),
+                        new AandC("Stun Seed"),
+                        new AandC("Entangling Roots"),
+                    };
+                    break;
+
+                case "Ashstone Core":
+                    /* Abilities
+                     * Slot 1: Feedback         | Burn
+                     * Slot 2: Crystal Overload | Stoneskin
+                     * Slot 3: Crystal Prison   | Instability
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Crystal Overload", () => buff("Crystal Overload") && hp > 0.50),
+                        new AandC("Feedback"),
+                        new AandC("Burn"),
+                        new AandC("Stoneskin"),
+                        new AandC("Crystal Prison"),
+                        new AandC("Instability"),
+                    };
+                    break;
+
+                case "Blazing Cindercrawler":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Burn             | Flamethrower
+                     * Slot 2: Brittle Webbing  | Heat Up
+                     * Slot 3: Magma Wave       | Cauterize
+                     *
+                     * Tactic Information:
+                     * Magma Wave is currently only used for clean up
+                     * Magma Wave could be used differently if we knew how many enemies there are
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Brittle Webbing",    () => ! debuff("Brittle Webbing")),
+                        new AandC("Heat Up",            () => ! buff("Heat Up")),
+                        new AandC("Magma Wave",         () => debuff("Turret") || debuff("Decoy")),
+                        new AandC("Cauterize",          () => hp < 0.6),
+                        new AandC("Burn"),
+                        new AandC("Flamethrower"),
+                    };
+                    break;
+
+                case "Blossoming Ancient":
+                    /* Abilities
+                     * Slot 1: Poisoned Branch  | Ironbark
+                     * Slot 2: Autumn Breeze    | Photosynthesis
+                     * Slot 3: Stun Seed        | Sunlight
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Photosynthesis",     () => ! buff("Photosynthesis") && hp < 0.8),
+                        new AandC("Poisoned Branch"),
+                        new AandC("Ironbark"),
+                        new AandC("Autumn Breeze"),
+                        new AandC("Stun Seed"),
+                        new AandC("Sunlight"),
+                    };
+                    break;
+
+                case "Cinder Kitten":
+                    /* Abilities
+                     * Slot 1: Claw     | Rend
+                     * Slot 2: Immolate | Leap 
+                     * Slot 3: Prowl    | Scorched Earth
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Scorched Earth", () => ! weather("Scorched Earth")),
+                        new AandC("Immolate",       () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth") ),
+                        new AandC("Leap",           () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Claw"),
+                        new AandC("Rend"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                case "Core Hound Pup":
+                    /* Abilities
+                     * Slot 1: Scratch  | Trash
+                     * Slot 2: Howl     | Dodge
+                     * Slot 3: Burn     | Burrow
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Scratch"),
+                        new AandC("Thrash"),
+                        new AandC("Howl"),
+                        new AandC("Dodge"),
+                        new AandC("Burn"),
+                        new AandC("Burrow"),
+                    };
+                    break;
+
+                case "Crazy Carrot":
+                    /* Changelog:
+                     * 2015-01-21: Blistering Cold has had its priority increased - Studio60
+                     *             Ironbark has had its priority reduced - Studio60
+                     * 2015-01-20: Blistering Cold is now used correctly - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Jab              | Ironbark
+                     * Slot 2: Acid Rain        | Aged Yolk
+                     * Slot 3: Blistering Cold  | Bash
+                     *
+                     * Tactic Information:
+                     * Acid Rain is not cast if the enemy is aquatic
+                     * 
+                     * TODO: Aged Yolk needs to check for positive/negative auras
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Blistering Cold",    () => ! debuff("Blistering Cold")),
+                        new AandC("Acid Rain",          () => ! weather("Cleansing Rain") && ! famEnemy(PF.Aquatic)),
+                        new AandC("Bash"),
+                        new AandC("Ironbark",           () => ! buff("Ironbark")),
+                        new AandC("Jab"),
+                        new AandC("Ironbark"),
+                        new AandC("Aged Yolk"),
+                    };
+                    break;
+
+                case "Crimson Geode":
+                case "Elementium Geode":
+                    /* Abilities
+                     * Slot 1: Feedback         | Spark
+                     * Slot 2: Crystal Overload | Amplify Magic
+                     * Slot 3: Stone Rush       | Elementium Bolt
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Crystal Overload",   () => buff("Crystal Overload") && hp > 0.50),
+                        new AandC("Feedback"),
+                        new AandC("Spark"),
+                        new AandC("Amplify Magic"),
+                        new AandC("Stone Rush"),
+                        new AandC("Elementium Bolt"),
+                    };
+                    break;
+
+                case "Dark Phoenix Hatchling":
+                    /* Abilities
+                     * Slot 1: Burn | Laser
+                     * Slot 2: Darkflame | Immolate
+                     * Slot 3: Conflagrate | Dark Rebirth
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Conflagrate",    () => debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth")),
+                        new AandC("Immolate",       () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth")),
+                        new AandC("Darkflame"),
+                        new AandC("Burn"),
+                        new AandC("Laser"),
+                        new AandC("Dark Rebirth"),
+                    };
+                    break;
+
+                case "Doom Bloom":
+                    /* Changelog:
+                     * 2015-01-20: Stun Seed is now only used if it is not already active - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Lash             | Bite
+                     * Slot 2: Consume Corpse   | Healing Wave
+                     * Slot 3: Stun Seed        | Entangling Roots
+                     *
+                     * Tactic Information:
+                     * Entangling Roots is cast only if we expect more than one additional turn
+                     * 
+                     * TODO: Consume Corpse  needs to detect dead allies
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Healing Wave",       () => hp < 0.7),
+                        new AandC("Stun Seed",          () => ! debuff("Stun Seed")),
+                        new AandC("Entangling Roots",   () => hpEnemy > 0.25),
+                        new AandC("Lash"),
+                        new AandC("Bite"),
+                        new AandC("Consume Corpse"),
+                    };
+                    break;
+
+                case "Droplet of Y'Shaarj":
+                    /* Changelog:
+                     * 2015-01-21: Dreadful Breath is now only used when health is above 50% (up from 40%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Corrosion | Swallow You Whole
+                     * Slot 2: Acid Rain | Expunge
+                     * Slot 3: Dreadful Breath | Curse of Doom
+                     *
+                     * Tactic Information:
+                     * Curse of Doom is cast early to give it time to explode
+                     * Acid Rain is not used against aquatic enemies
+                     * Dreadful Breath is only used during Cleansing Rain
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Curse of Doom",      () => hpEnemy > 0.8),
+                        new AandC("Swallow You Whole",  () => hp < 0.25),
+                        new AandC("Acid Rain",          () => ! weather("Cleansing Rain") && ! famEnemy(PF.Aquatic)),
+                        new AandC("Expunge"),
+                        new AandC("Dreadful Breath",    () => weather("Cleansing Rain") && hp > 0.5),
+                        new AandC("Corrosion"),
+                        new AandC("Swallow You Whole"),
+                    };
+                    break;
+
+                case "Electrified Razortooth":
+                    /* Abilities
+                     * Slot 1: Rip              | Jolt
+                     * Slot 2: Paralyzing Shock | Blood in the Water
+                     * Slot 3: Devour           | Lightning Shield
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",             () => hpEnemy < 0.20 ),
+                        new AandC("Rip"),
+                        new AandC("Jolt"),
+                        new AandC("Paralyzing Shock"),
+                        new AandC("Lightning Shield"),
+                        new AandC("Blood in the Water"),
+                    };
+                    break;
+
+                case "Fel Flame":
+                case "Searing Scorchling":
+                    /* Abilities
+                     * Slot 1: Burn         | Flame Breath
+                     * Slot 2: Immolate     | Scorched Earth
+                     * Slot 3: Conflagrate  | Immolation
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Scorched Earth", () => ! weather("Scorched Earth")),
+                        new AandC("Conflagrate",    () => debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth")),
+                        new AandC("Immolation",     () => ! buff("Immolation")),
+                        new AandC("Immolate",       () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth")),
+                        new AandC("Burn"),
+                        new AandC("Flame Breath"),
+                    };
+                    break;
+
+                case "Forest Sproutling":
+                    /* Changelog:
+                     * 2015-01-20: Sons of the Root is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Refuge is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-19: Refuge is now used defensively against 2-turn-attacks (Lift-Off etc.) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Lash                 | Club
+                     * Slot 2: Refuge               | Leech Seed
+                     * Slot 3: Fist of the Forest   | Sons of the Root
+                     *
+                     * Tactic Information:
+                     * Sons of the Root is only used defensively
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Sons of the Root",   () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Refuge",             () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Leech Seed",         () => ! debuff("Leech Seed")),
+                        new AandC("Fist of the Forest"),
+                        new AandC("Lash"),
+                        new AandC("Club"),
+                    };
+                    break;
+
+                case "Frigid Frostling":
+                    /* Abilities
+                     * Slot 1: Ice Lance    | Surge
+                     * Slot 2: Frost Nova   | Slippery Ice
+                     * Slot 3: Ice Tomb     | Howling Blast
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Frost Shock"),
+                        new AandC("Surge"),
+                        new AandC("Frost Nova"),
+                        new AandC("Slippery Ice"),
+                        new AandC("Ice Tomb"),
+                        new AandC("Howling Blast"),
+                    };
+                    break;
+
+                case "Gooey Sha-ling":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Seethe           | Creeping Ooze
+                     * Slot 2: Call Darkness    | Breath of Sorrow
+                     * Slot 3: Agony            | Death and Decay
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Call Darkness",      () => ! weather("Darkness")),
+                        new AandC("Breath of Sorrow",   () => ! debuff("Healing Reduction")),
+                        new AandC("Agony",              () => ! debuff("Agony")),
+                        new AandC("Death and Decay",    () => ! debuff("Death and Decay")),
+                        new AandC("Seethe"),
+                        new AandC("Creeping Ooze"),
+                    };
+                    break;
+
+                case "Grinder":
+                case "Lumpy": 
+                case "Pebble":
+                    /* Abilities
+                     * Slot 1: Stone Shot   | Stone Rush
+                     * Slot 2: Sandstorm    | Rupture
+                     * Slot 3: Rock Barrage | Quake
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Stone Shot"),
+                        new AandC("Stone Rush"),
+                        new AandC("Sandstorm"),
+                        new AandC("Rupture"),
+                        new AandC("Rock Barrage"),
+                        new AandC("Quake"),
+                    };
+                    break;
+
+                case "Hatespark the Tiny":
+                    /* Changelog:
+                     * 2015-01-20: Conflagrate is now checking for all burn effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Blast of Hatred  | Deep Burn
+                     * Slot 2: Conflagrate      | Cauterize
+                     * Slot 3: Flamethrower     | Armageddon
+                     *
+                     * TODO: Armageddon should check for other living team pets
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Flamethrower",       () => ! debuff("Burning")),
+                        new AandC("Armageddon",         () => hp < 0.1),
+                        new AandC("Conflagrate",        () => enemyIsBurning()),
+                        new AandC("Cauterize",          () => hp < 0.6),
+                        new AandC("Blast of Hatred"),
+                        new AandC("Deep Burn"),
+                    };
+                    break;
+
+                case "Jadefire Spirit":
+                    /* Changelog:
+                     * 2015-01-20: Fade is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Immolate is no longer used if it is already active - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Jade Breath      | Jade Claw
+                     * Slot 2: Emerald Presence | Immolate
+                     * Slot 3: Healing Flame    | Fade
+                     * 
+                     * Tactic Information:
+                     * Fade - Not sure if usable without backup pets. needs testing
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Fade",               () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Emerald Presence",   () => ! buff("Emerald Presence")),
+                        new AandC("Immolate",           () => ! debuff("Immolate")),
+                        new AandC("Healing Flame",      () => hp < 0.6),
+                        new AandC("Jade Breath"),	
+                        new AandC("Jade Claw"),	
+                    };
+                    break;
+
+                case "Jademist Dancer":
+                    /* Changelog:
+                     * 2015-01-19: 	Jadeskin is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     *              Rain Dance is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     *              Rain Dance is only used if pet health is below 80% (down from 100%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Steam Vent   | Jade Claw
+                     * Slot 2: Jadeskin     | Rain Dance
+                     * Slot 3: Acid Rain    | Geyser
+                     *
+                     * Tactic Information:
+                     * Geyser is only used if enemy is going to live long enough
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Acid Rain",      () => ! weather("Cleansing Rain")),
+                        new AandC("Jadeskin",       () => ! buff("Jadeskin") && hpEnemy > 0.15),
+                        new AandC("Rain Dance",     () => ! buff("Rain Dance")  && hp < 0.8 && hpEnemy > 0.15),
+                        new AandC("Geyser",         () => hpEnemy > 0.4),
+                        new AandC("Steam Vent"),
+                        new AandC("Jade Claw"),
+                    };
+                    break;
+
+                case "Jade Tentacle":
+                    /* Abilities
+                     * Slot 1: Scratch          | Poisoned Branch
+                     * Slot 2: Shell Shield     | Photosynthesis
+                     * Slot 3: Entangling Roots | Thorns
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Photosynthesis",     () =>  ! buff("Photosynthesis") && hp < 0.8),
+                        new AandC("Shell Shield",       () =>  ! buff("Shell Shield")),
+                        new AandC("Scratch"),
+                        new AandC("Poisoned Branch"),
+                        new AandC("Entangling Roots"),
+                        new AandC("Thorns"),
+                    };
+                    break;
+
+                case "Kirin Tor Familiar":
+                    /* Abilities
+                     * Slot 1: Beam             | Arcane Blast
+                     * Slot 2: Gravity          | Arcane Storm
+                     * Slot 3: Arcane Explosion | Rot
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Beam"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Gravity"),
+                        new AandC("Arcane Storm"),
+                        new AandC("Arcane Explosion"),
+                        new AandC("Dark Simulacrum"),
+                    };
+                    break;
+
+                case "Lava Crab":
+                    /* Abilities
+                     * Slot 1: Burn         | Survival
+                     * Slot 2: Shell Shield | Cauterize
+                     * Slot 3: Conflagrate  | Magma Wave
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Survival",       () => hp < 0.3),
+                        new AandC("Cauterize",      () => hp < 0.7),
+                        new AandC("Shell Shield",   () => ! buff("Shell Shield")),
+                        new AandC("Conflagrate"),
+                        new AandC("Burn"),
+                        new AandC("Magma Wave"),
+                    };
+                    break;
+
+                case "Lil' Ragnaros":
+                    /* Abilities
+                     * Slot 1: Sulfuras Smash   | Magma Wave
+                     * Slot 2: Magma Trap       | Conflagrate
+                     * Slot 3: Flamethrower     | Sons of the Flame
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Conflagrate",        () => debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth")),
+                        new AandC("Flamethrower",       () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth")),
+                        new AandC("Sons of the Flame"),
+                        new AandC("Magma Trap"),
+                        new AandC("Sulfuras Smash"),
+                        new AandC("Magma Wave"),
+                    };
+                    break;
+
+                case "Living Sandling":
+                    /* Abilities
+                     * Slot 1: Punch        | Sand Bolt
+                     * Slot 2: Stoneskin    | Sandstorm
+                     * Slot 3: Stone Rush   | Quicksand
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"), 
+                        new AandC("Sand Bolt"), 
+                        new AandC("Stoneskin"), 
+                        new AandC("Sandstorm"), 
+                        new AandC("Stone Rush"), 
+                        new AandC("Quicksand"),
+                    };
+                    break;
+
+                case "Molten Corgi":
+                    /* Abilities
+                     * Slot 1: Bark                 | Flamethrower
+                     * Slot 2: Superbark            | Cauterize
+                     * Slot 3: Puppies of the Flame | Inferno Herding
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Puppies of the Flame",   () => shouldIHide),
+                        new AandC("Cauterize",              () => hp < 0.7),
+                        new AandC("Superbark"),
+                        new AandC("Bark"),
+                        new AandC("Flamethrower"),
+                        new AandC("Inferno Herding"),
+                    };
+                    break;
+
+                case "Nightshade Sproutling":
+                    /* Changelog:
+                     * 2015-01-20: Blinding Poison is now only used if the enemy does not have Blinding Poison - Studio60
+                     * 2015-01-19: Nature's Ward conditions have been changed- Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Lash             | Poison Lash
+                     * Slot 2: Nature's Ward    | Call Darkness
+                     * Slot 3: Blinding Poison  | Fist of the Forest
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Poison Lash",        () => ! debuff("Poisoned")),
+                        new AandC("Nature's Ward",      () => hp < 0.9 && ! famEnemy(PF.Aquatic) && ! buff("Nature's Ward")),
+                        new AandC("Call Darkness"),
+                        new AandC("Blinding Poison",    () => ! debuff("Blinding Poison")),
+                        new AandC("Fist of the Forest"),	
+                        new AandC("Lash"),
+                    };
+                    break;
+
+                case "Ominous Flame":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Burn         | Spiritfire Bolt
+                     * Slot 2: Nimbus       | Scorched Earth
+                     * Slot 3: Conflagrate  | Forboding Curse
+                     * 
+                     * Tactic Information:
+                     * Nimbus is not really needed by this pet
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Scorched Earth",     () => ! weather("Scorched Earth")),
+                        new AandC("Forboding Curse",    () => ! debuff("Forboding Curse")),
+                        new AandC("Conflagrate"),
+                        new AandC("Burn"),
+                        new AandC("Spiritfire Bolt"),
+                        new AandC("Nimbus"),
+                    };
+                    break;
+
+                case "Pandaren Air Spirit":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Wild Winds
+                     * Slot 2: Whirlwind    | Soothing Mists
+                     * Slot 3: Cyclone      | Arcane Storm
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Wild Winds"),
+                        new AandC("Whirlwind"),
+                        new AandC("Soothing Mists"),
+                        new AandC("Arcane Storm"),
+                    };
+                    break;
+
+                case "Pandaren Earth Spirit":
+                    /* Abilities
+                     * Slot 1: Stone Shot       | Stone Rush
+                     * Slot 2: Rupture          | Rock Barrage
+                     * Slot 3: Crystal Prison   | Mudslide
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Stone Shot"),
+                        new AandC("Stone Rush"),
+                        new AandC("Rupture"),
+                        new AandC("Rock Barrage"),
+                        new AandC("Crystal Prison"),
+                        new AandC("Mudslide"),
+                    };
+                    break;
+
+                case "Pandaren Fire Spirit":
+                    /* Abilities
+                     * Slot 1: Burn         | Magma Wave
+                     * Slot 2: Immolate     | Flamethrower
+                     * Slot 3: Cauterize    | Conflagrate
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cauterize",      () => hp < 0.7),
+                        new AandC("Immolate",       () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth")),
+                        new AandC("Burn"),
+                        new AandC("Magma Wave"),
+                        new AandC("Flamethrower"),
+                        new AandC("Conflagrate"),
+                    };
+                    break;
+
+                case "Pandaren Water Spirit":
+                    /* Abilities
+                     * Slot 1: Water Jet    | Tidal Wave
+                     * Slot 2: Healing Wave | Whirlpool
+                     * Slot 3: Dive         | Geyser
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Dive"),
+                        new AandC("Water Jet"),
+                        new AandC("Tidal Wave"),
+                        new AandC("Healing Wave"),
+                        new AandC("Whirlpool"),
+                        new AandC("Geyser"),
+                    };
+                    break;
+
+                case "Phoenix Hatchling":
+                    /* Abilities
+                     * Slot 1: Burn         | Peck
+                     * Slot 2: Cauterize    | Immolate
+                     * Slot 3: Immolation   | Conflagrate
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cauterize",      () => hp < 0.7),
+                        new AandC("Immolation",     () => ! buff("Immolation")),
+                        new AandC("Immolate",       () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth")),
+                        new AandC("Conflagrate",    () => debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth") ),
+                        new AandC("Burn"),
+                        new AandC("Peck"),
+                    };
+                    break;
+
+                case "Ruby Droplet":
+                    /* Changelog:
+                     * 2015-01-20: Dive is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Bubble is now used to hide from huge attacks if it is faster or both pets have equal speed - Studio60
+                     * 2015-01-19: Dreadful Breath is only used if pet health is over 40% (up from 0%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Acid Touch       | Absorb
+                     * Slot 2: Dive             | Bubble
+                     * Slot 3: Plagued Blood    | Drain Blood
+                     */
+                    // very defensive pet
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Dive",           () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Bubble",         () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Plagued Blood",  () => ! debuff("Plagued")),
+                        new AandC("Drain Blood",    () => hp < 0.7),
+                        new AandC("Acid Touch"),
+                        new AandC("Absorb"),
+                    };
+                    break;
+
+                case "Ruby Sapling":
+                    /* Abilities
+                     * Slot 1: Scratch          | Ironbark
+                     * Slot 2: Thorns           | Poisened Branch
+                     * Slot 3: Photosynthesis   | Entangling Roots
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Photosynthesis",     () => ! buff("Photosynthesis") && hp < 0.8),
+                        new AandC("Shell Shield",       () => ! buff("Shell Shield")),
+                        new AandC("Scratch"),
+                        new AandC("Poisoned Branch"),
+                        new AandC("Thorns"),
+                        new AandC("Entangling Roots"),
+                    };
+                    break;
+
+                case "Sapphire Cub":
+                    /* Abilities
+                     * Slot 1: Lash         | Pounce
+                     * Slot 2: Rake         | Screech
+                     * Slot 3: Stone Rush   | Prowl
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lash"),
+                        new AandC("Pounch"),
+                        new AandC("Rake"),
+                        new AandC("Screech"),
+                        new AandC("Stone Rush"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                case "Singing Sunflower":
+                    /* Abilities
+                     * Slot 1: Lash             | Solar Beam
+                     * Slot 2: Photosynthesis   | Inspiring Song
+                     * Slot 3: Early Advantage  | Sunlight
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Photosynthesis",     () => ! buff("Photosynthesis") && hp < 0.8),
+                        new AandC("Early Advantage",    () => hp < hpEnemy),
+                        new AandC("Lash"),
+                        new AandC("Solar Beam"),
+                        new AandC("Inspiring Song"),
+                        new AandC("Sunlight"),
+                    };
+                    break;
+
+                case "Sinister Squashling":
+                    /* Abilities
+                     * Slot 1: Burn     | Poison Lash
+                     * Slot 2: Thorns   | Stun Seed
+                     * Slot 3: Plant    | Leech Seed
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burn"),
+                        new AandC("Poison Lash"),
+                        new AandC("Thorns"),
+                        new AandC("Stun Seed"),
+                        new AandC("Plant"),
+                        new AandC("Leech Seed"),
+                    };
+                    break;
+
+                case "Skunky Alemental":
+                    /* Changelog:
+                     * 2015-01-19: Mudslide is no longer used if it is already active - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Brew Bolt    | Barrel Toss
+                     * Slot 2: Mudslide     | Skunky Brew
+                     * Slot 3: Inebriate    | Explosive Brew
+                     *
+                     * Tactic Information:
+                     * Barrel Toss is prioritizes if barrel is ready.
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Explosive Brew",     () => ! debuff("Explosive Brew") && hpEnemy > 0.5),
+                        new AandC("Barrel Toss",        () => buff("Barrel Ready")),
+                        new AandC("Mudslide",           () => ! weather("Mudslide")),
+                        new AandC("Skunky Brew"),
+                        new AandC("Inebriate",          () => ! debuff("Inebriate")),
+                        new AandC("Brew Bolt"),
+                        new AandC("Barrel Toss"),
+                    };
+                    break;
+
+                case "Soul of the Forge":
+                    /* Changelog:
+                     * 2015-01-20: Extra Plating is now also used if both pets have the same speed - Studio60
+                     *             Stoneskin is now also used if both pets have the same speed - Studio60
+                     * 2015-01-19: Flamethrower now recognizes the "Flamethrower" debuff on enemies - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Deep Burn        | Sulfuras Smash
+                     * Slot 2: Extra Plating    | Stoneskin
+                     * Slot 3: Flamethrower     | Reforge
+                     *
+                     * Tactic Information:
+                     * Trying to keep defenses up 
+                     * Trying to keep the enemy burning
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Flamethrower",       () => ! debuff("Flamethrower")),
+                        new AandC("Extra Plating",      () => ! buff("Extra Plating") && speed >= speedEnemy),
+                        new AandC("Extra Plating",      () => buffLeft("Extra Plating") == 1 && speed < speedEnemy),
+                        new AandC("Stoneskin",          () => ! buff("Stoneskin") && speed >= speedEnemy),
+                        new AandC("Stoneskin",          () => buffLeft("Stoneskin") == 1 && speed < speedEnemy),
+                        new AandC("Reforge",            () => hp < 0.4),
+                        new AandC("Deep Burn"),
+                        new AandC("Sulfuras Smash"),
+                    };
+                    break;
+
+                case "Spirit of Summer":
+                    /* Abilities
+                     * Slot 1: Burn         | Flame Breath
+                     * Slot 2: Immolate     | Scorched Earth
+                     * Slot 3: Conflagrate  | Immolation
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Scorched Earth",     () => ! weather("Scorched Earth")),
+                        new AandC("Immolation",         () => ! buff("Immolation")),
+                        new AandC("Immolate",           () => ! debuff("Immolate") && ! debuff("Flamethrower") && ! weather("Scorched Earth")),
+                        new AandC("Conflagrate",        () => debuff("Immolate") || debuff("Flamethrower") || weather("Scorched Earth")),
+                        new AandC("Burn"),
+                        new AandC("Flame Breath"),
+                    };
+                    break;
+
+                case "Stout Alemental":
+                    /* Changelog:
+                     * 2015-01-20: Dive is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Brew Bolt    | Barrel Toss
+                     * Slot 2: Inebriate    | Explosive Brew
+                     * Slot 3: Dive         | Bubble
+                     */
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Dive",           () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Explosive Brew", () => ! debuff("Explosive Brew") && hpEnemy > 0.5),
+                        new AandC("Barrel Toss",    () => buff("Barrel Ready")),
+                        new AandC("Bubble",         () => shouldIHide),
+                        new AandC("Inebriate",      () => ! debuff("Inebriate")),
+                        new AandC("Brew Bolt"),
+                        new AandC("Barrel Toss"),
+                    };
+                    break;
+
+                case "Sun Sproutling":
+                    /* Changelog:
+                     * 2015-01-18: Photosynthesis is no longer used if it is already active (Studio60)
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Lash                 | Club
+                     * Slot 2: Photsynthesis        | Healing Wave
+                     * Slot 3: Fist of the Forest   | Solar Beam
+                     */
+                    // solar beam: try to use as finisher because of the recovery
+                    elemental_abilities = new List<AandC>() {
+                        new AandC("Photosynthesis",     () => hp < 0.9 && ! buff("Photosynthesis")),
+                        new AandC("Healing Wave",       () => hp < 0.7),
+                        new AandC("Fist of the Forest"),
+                        new AandC("Solar Beam",         () => hpEnemy < 0.2 || (weather("Sunny Day") && hpEnemy < 0.3)),
+                        new AandC("Lash"),
+                        new AandC("Club"),
+                    };
+                    break;
+
+                case "Tainted Waveling":
+                    /* Abilities
+                     * Slot 1: Ooze Touch   | Poison Spit
+                     * Slot 2: Acidic Goo   | Corrosion
+                     * Slot 3: Healing Wave | Creeping Ooze
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Acidic Goo",     () => ! debuff("Acidic Goo")),
+                        new AandC("Ooze Touch"),
+                        new AandC("Poison Spit"),
+                        new AandC("Corrosion"),
+                        new AandC("Healing Wave"),
+                        new AandC("Creeping Ooze"),
+                    };
+                    break;
+
+                case "Teldrassil Sproutling":
+                    /* Abilities
+                     * Slot 1: Scratch          | Ironbark
+                     * Slot 2: Thorns           | Poisoned Branch
+                     * Slot 3: Photosynthesis   | Entangling Roots
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Photosynthesis",     () =>  ! buff("Photosynthesis") && hp < 0.8),
+                        new AandC("Shell Shield",       () =>  ! buff("Shell Shield")),
+                        new AandC("Scratch"),
+                        new AandC("Poisoned Branch"),
+                        new AandC("Thorns"),
+                        new AandC("Entangling Roots"),
+                    };
+                    break;
+
+                case "Terrible Turnip":
+                    /* Abilities
+                     * Slot 1: Weakening Blow   | Tidal Wave
+                     * Slot 2: Leech Seed       | Inspiring Song
+                     * Slot 3: Sunlight         | Sons of the Root
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Weakening Blow", () =>  hpEnemy > 0.05 ),
+                        new AandC("Tidal Wave"),
+                        new AandC("Leech Seed"),
+                        new AandC("Inspiring Song"),
+                        new AandC("Sunlight"),
+                        new AandC("Sons of the Root"),
+                    };
+                    break;
+
+                case "Thundertail Flapper":
+                    /* Abilities
+                     * Slot 1: Tail Slap        | Jolt
+                     * Slot 2: Buried Treasure  | Lightning Shield
+                     * Slot 3: Thunderbolt      | Beaver Dam
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Tail Slap"),
+                        new AandC("Jolt"),
+                        new AandC("Buried Treasure"),
+                        new AandC("Lightning Shield"),
+                        new AandC("Thunderbolt"),
+                        new AandC("Beaver Dam"),
+                    };
+                    break;
+
+                case "Tiny Bog Beast":
+                    /* Abilities
+                     * Slot 1: Crush        | Clobber
+                     * Slot 2: Lash         | Leap
+                     * Slot 3: Poison Lash  | Rampage
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",           () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Crush"),
+                        new AandC("Clobber"),
+                        new AandC("Lash"),
+                        new AandC("Poison Lash"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+
+                case "Tiny Snowman":
+                    /* Abilities
+                     * Slot 1: Snowball         | Magic Hat
+                     * Slot 2: Call Blizzard    | Frost Nova
+                     * Slot 3: Howling Blast    | Deep Freeze
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Snowball"),
+                        new AandC("Magic Hat"),
+                        new AandC("Call Blizzard"),
+                        new AandC("Frost Nova"),
+                        new AandC("Howling Blast"),
+                        new AandC("Deep Freeze"),
+                    };
+                    break;
+
+                case "Tiny Twister":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Wild Winds
+                     * Slot 2: Flyby        | Bash
+                     * Slot 3: Cyclone      | Call Lightning
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Wild Winds"),
+                        new AandC("Flyby"),
+                        new AandC("Bash"),
+                        new AandC("Sandstorm"),
+                    };
+                    break;
+
+                case "Venus":
+                    /* Abilities
+                     * Slot 1: Lash         | Poison Lash
+                     * Slot 2: Sunlight     | Plant
+                     * Slot 3: Stun Seed    | Leech Seed
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lash"),
+                        new AandC("Poison Lash"),
+                        new AandC("Sunlight"),
+                        new AandC("Plant"),
+                        new AandC("Stun Seed"),
+                        new AandC("Leech Seed"),
+                    };
+                    break;
+
+                case "Water Waveling":
+                    /* Abilities
+                     * Slot 1: Water Jet    | Ice Lance
+                     * Slot 2: Frost Nova   | Frost Shock
+                     * Slot 3: Geyser       | Tidal Wave
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Water Jet"),
+                        new AandC("Ice Lance"),
+                        new AandC("Frost Nova"),
+                        new AandC("Frost Shock"),
+                        new AandC("Geyser"),
+                        new AandC("Tidal Wave"),
+                    };
+                    break;
+
+                case "Withers":
+                    /* Abilities
+                     * Slot 1: Scratch          | Ironbark
+                     * Slot 2: Thorns           | Poisoned Branch
+                     * Slot 3: Photosynthesis   | Entangling Roots
+                     */
+                    elemental_abilities = new List<AandC>() 
+                    {
+                        new AandC("Photosynthesis",     () => ! buff("Photosynthesis") && hp < 0.8),
+                        new AandC("Shell Shield",       () => ! buff("Shell Shield")),
+                        new AandC("Scratch"),
+                        new AandC("Poisoned Branch"),
+                        new AandC("Thorns"),
+                        new AandC("Entangling Roots"),
+                    };
+                    break;
+            
+                default:
+                    ///////////////////////////
+                    // Unknown Elemental Pet //
+                    ///////////////////////////
+                    Logger.Alert("Unknown elemental pet: " + petName);
+                    elemental_abilities = null;
+                    break;
             }
+
             return elemental_abilities;
         }
     }

--- a/Prosto_Pets/Pets/Flying.cs
+++ b/Prosto_Pets/Pets/Flying.cs
@@ -24,361 +24,1180 @@ namespace Prosto_Pets
 
             List<AandC> flying_abilities;
 
-
-
-////////////////////////
-// BALLOONS && KITES //
-////////////////////////
-            if (petName == "Dragon Kite")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-			new AandC( "Call Lightning" 	),	// Slot 2
-			new AandC( "Roar" 			),	// Slot 2
-			new AandC( "Volcano" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Tuskarr Kite")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 2
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Frost Shock" 	),	// Slot 1
-			new AandC( "Wild Winds" 		),	// Slot 2
-			new AandC( "Flyby" 			),	// Slot 3
-			new AandC( "Reckless Strike" ),	// Slot 3
-		}
-                    //////////
-                    // BATS //
-                    //////////
-            ;
-            else if (petName == "Bat" || petName == "Tirisfal Batling")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Hawk Eye",	() =>		! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Leech Life" 		),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 2
-			new AandC( "Reckless Strike" ),	// Slot 3
-			new AandC( "Nocturnal Strike"),	// Slot 3
-		}
-                    //////////////////-
-                    // BIRDS OF PREY //
-                    //////////////////-
-            ;
-            else if (petName == "Blue Mini Jouster" || petName == "Dragonbone Hatchling" || petName == "Fledgling Buzzard" || petName == "Gold Mini Jouster" || petName == "Imperial Eagle Chick" || petName == "Tickbird Hatchling" || petName == "White Tickbird Hatchling")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Hawk Eye",	() =>		! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-		}
-            ;
-            else if (petName == "Brilliant Kaliri")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Predatory Strike", () =>	hpEnemy < 0.25 ),	// Slot 3
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 2
-			new AandC( "Shriek", () => 			! debuff("Attack Reduction") ),	// Slot 2
-			new AandC( "Nocturnal Strike"),	// Slot 3
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Quills" 			),	// Slot 1
-		}
-            ;
-            else if (petName == "Ji-Kun Hatchling")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Acidic Goo",  () =>	! debuff("Acidic Goo") ),	// Slot 2
-			new AandC( "Slicing Wind",  () =>  ! debuff("Wild Winds") ),	// Slot 1
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Wild Winds" 		),	// Slot 2
-			new AandC( "Flock" 			),	// Slot 3
-			new AandC( "Caw" 			),	// Slot 3
-		}
-                    //////////////-
-                    // FIREFLIES //
-                    //////////////-
-            ;
-            else if (petName == "Darkmoon Glowfly")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Dazzling Dance",  () =>speed < speedEnemy && ! buff("Dazzling Dance") ),	// Slot 3
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Glowing Toxin" 	),	// Slot 2
-			new AandC( "Sting" 			),	// Slot 2
-			new AandC( "Confusing Sting" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Effervescent Glowfly" || petName == "Firefly" || petName == "Mei Li Sparkler" || petName == "Shrine Fly")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Confusing Sting",  () => debuff("Confusing Sting") ),  // Slot 2
-			new AandC( "Swarm", () =>			! debuff("Shattered Defenses")),  // Slot 3
-			new AandC( "Glowing Toxin",	() =>	! debuff("Glowing Toxin")),  // Slot 3
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Cocoon Strike" 	),	// Slot 2
-		}
-            ;
-            else if (petName == "Tiny Flamefly")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Alpha Strike" 	),	// Slot 1
-			new AandC( "Immolate" 		),	// Slot 2
-			new AandC( "Hiss" 			),	// Slot 2
-			new AandC( "Swarm" 			),	// Slot 3
-			new AandC( "Adrenaline Rush" ),	// Slot 3
-		}
-                    //////////
-                    // FOWL //
-                    //////////
-            ;
-            else if (petName == "Ancona Chicken" || petName == "Chicken" || petName == "Szechuan Chicken" || petName == "Westfall Chicken")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Squawk" 			),	// Slot 2
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-			new AandC( "Egg Barrage" 	),	// Slot 3
-			new AandC( "Flock" 			),	// Slot 3
-		}
-            ;
-            else if (petName == "Highlands Turkey" || petName == "Plump Turkey" || petName == "Turkey")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Squawk" 			),	// Slot 2
-			new AandC( "Gobble Strike",  () =>speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Food Coma" 		),	// Slot 3
-			new AandC( "Flock" 			),	// Slot 3
-		}
-                    //////////////////////
-                    // GULLS && RAVENS //
-                    //////////////////////
-            ;
-            else if (petName == "Crow")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Alpha Strike" 	),	// Slot 1
-			new AandC( "Squawk" 			),	// Slot 2
-			new AandC( "Call Darkness" 	),	// Slot 2
-			new AandC( "Murder" 			),	// Slot 3
-			new AandC( "Nocturnal Strike"),	// Slot 3
-		}
-            ;
-            else if (petName == "Gilnean Raven")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Alpha Strike" 	),	// Slot 1
-			new AandC( "Drakflame" 		),	// Slot 2
-			new AandC( "Call Darkness" 	),	// Slot 2
-			new AandC( "Nocturnal Strike"),	// Slot 3
-			new AandC( "Nevermore" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Rustberg Gull" || petName == "Sandy Petrel" || petName == "Sea Gull")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),  // Slot 3
-			new AandC( "Hawk Eye",	() =>		! buff("Hawk Eye") ),  // Slot 2
-			new AandC( "Adrenaline Rush", () =>		! buff("Adrenaline") ),  // Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-		}
-                    //////////-
-                    // MOTHS //
-                    //////////-
-            ;
-            else if (petName == "Amber Moth" || petName == "Blue Moth" || petName == "Crimson Moth" || petName == "Forest Moth" || petName == "Fungal Moth" || petName == "Garden Moth" || petName == "Gilded Moth" || petName == "Grey Moth" || petName == "Luyu Moth" || petName == "Oasis Moth" || petName == "Red Moth" || petName == "Silky Moth" || petName == "Swamp Moth" || petName == "Tainted Moth" || petName == "White Moth" || petName == "Yellow Moth")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Alpha Strike" 	),	// Slot 1
-			new AandC( "Cocoon Strike" 	),	// Slot 2
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-			new AandC( "Moth Balls" 		),	// Slot 3
-			new AandC( "Moth Dust" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Imperial Moth")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Wild Winds" 		),	// Slot 1
-			new AandC( "Cocoon Strike" 	),	// Slot 2
-			new AandC( "Moth Balls" 		),	// Slot 2
-			new AandC( "Moth Dust" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Skywisp Moth")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Call Lightning" 	),	// Slot 3
-			new AandC( "Counterspell", () => 	speed > speedEnemy ),	// Slot 2
-			new AandC( "Cocoon Strike" 	),	// Slot 2
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Reckless Strike" ),	// Slot 1
-			new AandC( "Moth Dust" 		),	// Slot 3
-		}
-
-                    //////////////
-                    // MYTHICAL //
-                    //////////////
-            ;
-            else if (petName == "Cenarion Hatchling" || petName == "Hippogryph Hatchling")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Rush", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Quills" 			),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 2
-			new AandC( "Reckless Strike" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Gryphon Hatchling" || petName == "Wildhammer Gryphon Hatchling")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Squawk" 			),	// Slot 2
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-			new AandC( "Flock" 			),	// Slot 3
-		}
-            ;
-            else if (petName == "Guardian Cub")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Onyx Bite"		),	// Slot 1
-			new AandC( "Roar" 			),	// Slot 2
-			new AandC( "Wild Winds" 		),	// Slot 2
-			new AandC( "Reckless Strike" ),	// Slot 3
-		}
-                    ////////////////-
-                    // NETHER RAYS //
-                    ////////////////-
-            ;
-            else if (petName == "Fledgling Nether Ray" || petName == "Nether Ray Fry")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 2
-			new AandC( "Slicing Wind" 	),	// Slot 2
-			new AandC( "Shadow Shock" 	),	// Slot 3
-			new AandC( "Lash" 			),	// Slot 3
-		}
-                    //////////
-                    // OWLS //
-                    //////////
-            ;
-            else if (petName == "Crested Owl" || petName == "Great Horned Owl" || petName == "Hawk Owl" || petName == "Snowy Owl")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Shriek", () => 			! debuff("Attack Reduction") ),	// Slot 2
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Quills" 			),	// Slot 1
-			new AandC( "Cyclone" 		),	// Slot 2
-			new AandC( "Nocturnal Strike"),	// Slot 3
-			new AandC( "Predatory Strike"),	// Slot 3
-		}
-                    ////////////-
-                    // PARROTS //
-                    ////////////-
-            ;
-            else if (petName == "Cockatiel" || petName == "Green Wing Macaw" || petName == "Hyacinth Macaw" || petName == "Parrot" || petName == "Polly" || petName == "Senegal")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Hawk Eye" 		),	// Slot 2
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-		}
-            ;
-            else if (petName == "Miniwing")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 2
-			new AandC( "Shriek", () => 			! debuff("Attack Reduction") ),	// Slot 2
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Quills" 			),	// Slot 1
-			new AandC( "Nocturnal Strike"),	// Slot 3
-			new AandC( "Predatory Strike"),	// Slot 3
-		}
-                    //////////////////-
-                    // MISCELLANEOUS //
-                    //////////////////-
-            ;
-            else if (petName == "Waterfly")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Healing Stream", () =>      hp < 0.7 	),	// Slot 2
-			new AandC( "Lift-Off"                               ),	// Slot 3
-			new AandC( "Dodge"                                  ),	// Slot 3
-			new AandC( "Barbed Stinger", () =>	    ! debuff("Poisoned") ),	// Slot 1
-			new AandC( "Alpha Strike",	 () =>		speed > speedEnemy ),	// Slot 1
-			new AandC( "Puncture Wound", () =>      debuff("Poisoned") 			),	// Slot 2
-			new AandC( "Barbed Stinger"      ),	// Slot 1 Uncond
-			new AandC( "Alpha Strike"        ),	// Slot 1 Uncond
-		}
-            ;
-            else if (petName == "Jade Crane Chick")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Hawk Eye",	() =>		! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Jadeskin" 		),	// Slot 2
-			new AandC( "Flock"			),	// Slot 3
-		}
-            ;
-            else if (petName == "Pterrordax Hatchling")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Ancient Blessing",  () => !buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Lift-Off"		),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Flyby" 			),	// Slot 1
-			new AandC( "Apocalypse" 		),	// Slot 2
-			new AandC( "Feign Death"		),	// Slot 3
-		}
-            ;
-            else if (petName == "Tiny Sporebat")
-                flying_abilities = new List<AandC>() 
-		{
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Creeping Fungus" ),	// Slot 2
-			new AandC( "Leech Seed" 		),	// Slot 2
-			new AandC( "Spore Shrooms" 	),	// Slot 3
-			new AandC( "Confusing Sting" ),	// Slot 3
-		};
-            //////////////////-
-
-            else // Unknown pet
+            switch (petName)
             {
-                Logger.Alert("Unknown flying pet: " + petName);
-                return null;
+                case "Amberbarb Wasp":
+                case "Bloodsting Wasp":
+                case "Twilight Wasp": 
+                case "Wood Wasp":
+                case "Bone Wasp":
+                    /* Changelog:
+                     * 2015-01-20: Puncture Wound is now checking for all poison effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Barbed Stinger   | Bite
+                     * Slot 2: Focus            | Predatory Strike
+                     * Slot 3: Puncture Wound   | Ravage
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Ravage",             () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Barbed Stinger",     () => ! debuff("Poisoned")), 
+                        new AandC("Puncture Wound",     () => enemyIsPoisoned()),
+                        new AandC("Focus",              () => ! buff("Focused")),
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Puncture Wound"),
+                        new AandC("Barbed Stinger"),
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Amber Moth":
+                case "Blue Moth":
+                case "Crimson Moth":
+                case "Forest Moth":
+                case "Fungal Moth":
+                case "Garden Moth":
+                case "Gilded Moth":
+                case "Grey Moth":
+                case "Luyu Moth":
+                case "Oasis Moth":
+                case "Red Moth":
+                case "Silky Moth":
+                case "Swamp Moth":
+                case "Tainted Moth":
+                case "White Moth":
+                case "Yellow Moth":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Alpha Strike
+                     * Slot 2: Cocoon Strike    | Adrenaline Rush
+                     * Slot 3: Moth Balls       | Moth Dust
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Slicing Wind"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Cocoon Strike"),
+                        new AandC("Adrenaline Rush"),
+                        new AandC("Moth Balls"),
+                        new AandC("Moth Dust"),
+                    };
+                    break;
+
+                case "Ancona Chicken":
+                case "Chicken":
+                case "Szechuan Chicken":
+                case "Westfall Chicken":
+                    /* Abilities
+                     * Slot 1: Peck         | Slicing Wind
+                     * Slot 2: Squawk       | Adrenaline Rush
+                     * Slot 3: Egg Barrage  | Flock
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Peck"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Squawk"),
+                        new AandC("Adrenaline Rush"),
+                        new AandC("Egg Barrage"),
+                        new AandC("Flock"),
+                    };
+                    break;
+
+                case "Ashwing Moth":
+                    /* Changelog:
+                     * 2015-01-20: Cocoon Strike is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Alpha Strike | Wild Winds
+                     * Slot 2: Nimbus       | Cocoon Strike
+                     * Slot 3: Moth Balls   | Moth Dust
+                     *
+                     * Tactic Information
+                     * Moth balls deal unreliable damage, but become useful if we are faster than the enemy
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Nimbus", () => ! buff("Nimbus")),
+                        new AandC("Cocoon Strike", () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Moth Balls", () => ! debuff("Speed Reduction") && speed < speedEnemy && speed > speedEnemy * 0.75),
+                        new AandC("Moth Dust"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Wild Winds"),
+                    };
+                    break;
+
+                case "Axebeak Hatchling":
+                case "Junglebeak":
+                case "Fruit Hunter":
+                    /* Changelog:
+                     * 2015-01-20: Nocturnal Strike is now checking for all blindness effects - Studio60
+                     *             Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-19: Rain Dance is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     *             Rain Dance is only used if pet health is below 80% (down from 100%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Slicing Wind | Peck
+                     * Slot 2: Rain Dance   | Flyby
+                     * Slot 3: Lift-Off     | Nocturnal Strike
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Lift-Off",           () => strong("Lift-Off") || (shouldIHide && speed >= speedEnemy)),
+                        new AandC("Nocturnal Strike",   () => enemyIsBlinded()),
+                        new AandC("Rain Dance",         () => ! buff("Rain Dance")  && hp < 0.8 && hpEnemy > 0.15),
+                        new AandC("Flyby",              () => ! debuff("Weakened Defenses")),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Peck"),
+                    };
+                    break;
+
+                case "Azure Crane Chick":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Quills           | Flock
+                     * Slot 2: Cleansing Rain   | Healing Stream
+                     * Slot 3: Reckless Strike  | Surge
+                     *
+                     * Tactic Information:
+                     * Reckless Strike is risky if used against magic pets due to incoming spiky magic damage
+                     * 
+                     * TODO: Cleansing Rain is less important if pet does not have Surge
+                     */             
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Cleansing Rain",     () => ! buff("Cleansing Rain")),
+                        new AandC("Surge",              () => famEnemy(PF.Elemental) || famEnemy(PF.Dragonkin) || buff("Cleansing Rain")),
+                        new AandC("Quills",             () => speed > speedEnemy),
+                        new AandC("Healing Stream",     () => hp < 0.8),
+                        new AandC("Reckless Strike",    () => ! famEnemy(PF.Magic)),
+                        new AandC("Quills"),
+                        new AandC("Flock"),
+                    };
+                    break;
+
+                case "Bat":
+                case "Tirisfal Batling":
+                    /* Abilities
+                     * Slot 1: Bite             | Leech Life
+                     * Slot 2: Screech          | Hawk Eye
+                     * Slot 3: Reckless Strike  | Nocturnal Strike
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Bite"),
+                        new AandC("Leech Life"),
+                        new AandC("Screech"),
+                        new AandC("Reckless Strike"),
+                        new AandC("Nocturnal Strike"),
+                    };
+                    break;
+
+                case "Blue Mini Jouster":
+                case "Dragonbone Hatchling":
+                case "Fledgling Buzzard":
+                case "Gold Mini Jouster":
+                case "Imperial Eagle Chick":
+                case "Tickbird Hatchling": 
+                case "White Tickbird Hatchling":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Thrash
+                     * Slot 2: Hawk Eye     | Adrenaline Rush
+                     * Slot 3: Lift-Off     | Cyclone
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Lift-Off"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Thrash"),
+                        new AandC("Adrenaline Rush"),
+                    };
+                    break;
+
+                case "Brilliant Bloodfeather":
+                    /* Changelog:
+                     * 2015-01-20: Quills is now also used with high priority if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Quills           | Peck
+                     * Slot 2: Hawk Eye         | Accuracy
+                     * Slot 3: Reckless Strike  | Drain Blood
+                     *
+                     * Tactic Information:
+                     * Reckless Strike is isky if used against magic pets due to incoming spiky magic damage
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Accuracy",           () => buff("Blinded")),
+                        new AandC("Quills",             () => speed >= speedEnemy),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Reckless Strike",    () => ! famEnemy(PF.Magic)),
+                        new AandC("Drain Blood",        () => hp < 0.6),
+                        new AandC("Quills"),
+                        new AandC("Peck"),
+                    };
+                    break;
+
+                case "Brilliant Kaliri":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Peck             | Quills
+                     * Slot 2: Shriek           | Cyclone
+                     * Slot 3: Nocturnal Strike | Predatory Strike
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Shriek",             () => ! debuff("Attack Reduction")),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Peck"),
+                        new AandC("Quills"),
+                    };
+                    break;
+
+                case "Brilliant Spore":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Reckless Strike  | Creeping Fungus
+                     * Slot 2: Spiked Skin      | Blinding Powder
+                     * Slot 3: Spore Shrooms    | Explode
+                     * 
+                     * Tactic Information:
+                     * Reckless Strike is low priority but always used, because it might be the only available attack
+                     * 
+                     * TODO: Use Blinding Powder if big attack is anticipated
+                     * TODO: Spore Shrooms should be used if more than one enemy pet is alive
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Explode",            () => hp < 0.1),
+                        new AandC("Creeping Fungus",    () => ! debuff("Creeping Fungus") && weather("Moonlight")),  
+                        new AandC("Spiked Skin",        () => ! buff("Spiked Skin")),
+                        new AandC("Spore Shrooms",      () => hpEnemy > 0.6),
+                        new AandC("Reckless Strike"),
+                        new AandC("Creeping Fungus",    () => ! debuff("Creeping Fungus")),                    
+                        new AandC("Blinding Powder"),
+                    };
+                    break;
+
+                case "Cenarion Hatchling":
+                case "Hippogryph Hatchling":
+                    /* Abilities
+                     * Slot 1: Peck             | Quills
+                     * Slot 2: Screech          | Rush
+                     * Slot 3: Reckless Strike  | Lift-Off
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Rush",               () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Lift-Off"),
+                        new AandC("Peck"),
+                        new AandC("Quills"),
+                        new AandC("Screech"),
+                        new AandC("Reckless Strike"),
+                    };
+                    break;
+
+                case "Chi-Chi, Hatchling of Chi-Ji":
+                    /* Changelog:
+                     * 2015-01-19: Tranquility is not used if it is already active - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Fire Quills  | Alpha Strike
+                     * Slot 2: Tranquility  | Wild Magic
+                     * Slot 3: Ethereal     | Feign Death
+                     * 
+                     * TODO: Use Feign Death if we have another pet available
+                     * TODO: Recast Wild Magic earlier if we are slower
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Ethereal",       () => shouldIHide),
+                        new AandC("Tranquility",    () => hp < 0.8 && ! buff("Tranquility") && hpEnemy > 0.15),
+                        new AandC("Wild Magic",     () => ! debuff ("Wild Magic")),
+                        new AandC("Fire Quills"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Feign Death"),
+                    };
+                    break;
+
+                case "Cockatiel":
+                case "Green Wing Macaw":
+                case "Hyacinth Macaw":
+                case "Parrot":
+                case "Polly":
+                case "Senegal":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Thrash
+                     * Slot 2: Hawk Eye     | Adrenaline Rush
+                     * Slot 3: Lift-Off     | Cynclone
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Lift-Off"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Thrash"),
+                        new AandC("Hawk Eye"),
+                        new AandC("Adrenaline Rush"),
+                    };
+                    break;
+
+                case "Crested Owl":
+                case "Great Horned Owl":
+                case "Hawk Owl":
+                case "Snowy Owl":
+                    /* Abilities
+                     * Slot 1: Peck             | Quills
+                     * Slot 2: Shriek           | Cyclone
+                     * Slot 3: Nocturnal Strike | Predatory Strike
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shriek",             () => ! debuff("Attack Reduction")),
+                        new AandC("Peck"),
+                        new AandC("Quills"),
+                        new AandC("Cyclone"),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Predatory Strike"),
+                    };
+                    break;
+
+                case "Crimson Spore":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Sting            | Creeping Fungus
+                     * Slot 2: Blinding Powder  | Spiked Skin
+                     * Slot 3: Spore Shrooms    | Explode
+                     * 
+                     * TODO: Use Blinding Powder if big attack is anticipated
+                     * TODO: Spore Shrooms should be used if more than one enemy pet is alive
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Explode",            () => hp < 0.1),
+                        new AandC("Creeping Fungus",    () => ! debuff("Creeping Fungus") && weather("Moonlight")),  
+                        new AandC("Spiked Skin"),
+                        new AandC("Spore Shrooms",      () => hpEnemy > 0.6),
+                        new AandC("Sting"),
+                        new AandC("Creeping Fungus"),
+                        new AandC("Blinding Powder"),
+                    };
+                    break;
+
+                case "Crow":
+                    /* Abilities
+                     * Slot 1: Peck     | Alpha Strike
+                     * Slot 2: Squawk   | Call Darkness
+                     * Slot 3: Murder   | Nocturnal Strike
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Peck"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Squawk"),
+                        new AandC("Call Darkness"),
+                        new AandC("Murder"),
+                        new AandC("Nocturnal Strike"),
+                    };
+                    break;
+
+                case "Darkmoon Glowfly":
+                    /* Abilities
+                     * Slot 1: Scratch          | Slicing Wind
+                     * Slot 2: Glowing Toxin    | Sting
+                     * Slot 3: Confusing Sting  | Dazzling Dance
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Dazzling Dance",     () =>speed < speedEnemy && ! buff("Dazzling Dance")),
+                        new AandC("Scratch"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Glowing Toxin"),
+                        new AandC("Sting"),
+                        new AandC("Confusing Sting"),
+                    };
+                    break;
+
+                case "Dragon Kite":
+                    /* Abilities
+                     * Slot 1: Breath           | Tail Sweep
+                     * Slot 2: Call Lightning   | Roar 
+                     * Slot 3: Volcano          | Lift-Off
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lift-Off"),
+                        new AandC("Breath"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Call Lightning"),
+                        new AandC("Roar"),
+                        new AandC("Volcano"),
+                    };
+                    break;
+
+                case "Dread Hatchling":
+                    /* Changelog:
+                     * 2015-01-20: Nocturnal Strike is now checking for all blindness effect - Studio60
+                     *             Nocturnal Strike is now used more often - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Peck             | Shadow Talon
+                     * Slot 2: Call Darkness    | Consume Corpse
+                     * Slot 3: Nocturnal Strike | Anzu's Blessing
+                     * 
+                     * TODO: Nocturnal Strike should check if pet has selected Call Darkness
+                     * TODO: Consume Corpse needs to check for dead allies
+                     */
+                    // (missing condition) nocturnal strike: should check if pet has skill darkness
+                    // (missing condition) consume corpse: requires e.g. "deadAllies > 0"
+                    // nocturnal strike: only during darkness
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Nocturnal Strike",   () => enemyIsBlinded()),
+                        new AandC("Anzu's Blessing",    () => ! buff("Attack Boost")),
+                        new AandC("Call Darkness",      () => ! weather("Darkness")),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Peck"),
+                        new AandC("Shadow Talon"),
+                        new AandC("Consume Corpse"),
+                    };
+                    break;
+
+                case "Everbloom Peachick":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Quills           | Peck
+                     * Slot 2: Hawk Eye         | Accuracy
+                     * Slot 3: Reckless Strike  | Squawk
+                     * 
+                     * Tactic Information:
+                     * Accuracy is not that important for this pet
+                     * Reckless strike is risky if used against magic pets due to incoming spiky magic damage
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Quills",             () => speed > speedEnemy),
+                        new AandC("Squawk",             () => ! debuff("Attack Reduction")),                    
+                        new AandC("Reckless Strike",    () => ! famEnemy(PF.Magic)),
+                        new AandC("Quills"),
+                        new AandC("Peck"),
+                        new AandC("Accuracy"),
+                    };
+                    break;
+
+                case "Effervescent Glowfly":
+                case "Firefly":
+                case "Mei Li Sparkler":
+                case "Shrine Fly":
+                    /* Abilities
+                     * Slot 1: Scratch          | Slicing Wind
+                     * Slot 2: Confusing Sting  | Cocoon Strike
+                     * Slot 3: Swarm            | Glowing Toxin
+                     */ 
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Confusing Sting",    () => debuff("Confusing Sting")),
+                        new AandC("Swarm",              () => ! debuff("Shattered Defenses")),
+                        new AandC("Glowing Toxin",      () => ! debuff("Glowing Toxin")),
+                        new AandC("Scratch"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Cocoon Strike"),
+                    };
+                    break;
+
+                case "Firewing":
+                    /* Changelog:
+                     * 2015-01-20: Deep Burn is now checking for all burn effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Alpha Strike | Deep Burn 
+                     * Slot 2: Scorched Earth | Sunlight
+                     * Slot 3: Healing Flame | Murder
+                     * 
+                     * Tactic Information:
+                     * Alpha Strike is not wasted on Dragonkin
+                     * Deep Burn is prioritizes if the enemy is burning
+                     * Healing Flame is used later in Sunlight, because it heals more
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Deep Burn",      () => enemyIsBurning()),
+                        new AandC("Scorched Earth", () => ! weather("Scorched Earth")),
+                        new AandC("Sunlight",       () => ! weather("Sunny Day")),
+                        new AandC("Healing Flame",  () => (weather("Sunny Day") && hp < 0.5) || (! weather("Sunny Day") && hp < 0.75)),
+                        new AandC("Alpha Strike",   () => speed > speedEnemy && ! famEnemy(PF.Dragonkin)),
+                        new AandC("Murder"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Deep Burn"),
+                    };
+                    break;
+
+                case "Flamering Moth":
+                    /* Changelog:
+                     * 2015-01-20: Cocoon Strike is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Burn             | Alpha Strike
+                     * Slot 2: Cocoon Strike    | Healing Flame
+                     * Slot 3: Nimbus           | Moth Dust
+                     * 
+                     * Tactic Information:
+                     * Nimbus is usually not important for this pet
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Cocoon Strike",  () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Healing Flame",  () => hp < 0.75),
+                        new AandC("Moth Dust"),
+                        new AandC("Burn"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Nimbus",         () => ! buff("Nimbus")),
+                    };
+                    break;
+
+                case "Fledgling Nether Ray":
+                case "Nether Ray Fry":
+                    /* Abilities
+                     * Slot 1: Bite         | Arcane Blast
+                     * Slot 2: Tail Sweep   | Slicing Wind
+                     * Slot 3: Shadow Shock | Lash
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Shadow Shock"),
+                        new AandC("Lash"),
+                    };
+                    break;
+
+                case "Gilnean Raven":
+                    /* Abilities
+                     * Slot 1: Peck             | Alpha Strike
+                     * Slot 2: Darkflame        | Call Darkness
+                     * Slot 3: Nocturnal Strike | Nevermore
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Peck"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Drakflame"),
+                        new AandC("Call Darkness"),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Nevermore"),
+                    };
+                    break;
+
+                case "Golden Dawnfeather":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Quills           | Peck
+                     * Slot 2: Sunlight         | Hawk Eye
+                     * Slot 3: Reckless Strike  | Love Potion
+                     * 
+                     * Tactic Information:
+                     * Reckless Strike is risky if used against magic pets due to incoming spiky magic damage
+                     * Love Potion is stronger during Sunlight so we can heal later
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Sunlight",           () => ! weather("Sunny Day")),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Reckless Strike",    () => ! famEnemy(PF.Magic)),
+                        new AandC("Love Potion",        () => (weather("Sunny Day") && hp < 0.5) || (! weather("Sunny Day") && hp < 0.75)),
+                        new AandC("Quills"),
+                        new AandC("Peck"),
+                    };
+                    break;
+
+                case "Gryphon Hatchling":
+                case "Wildhammer Gryphon Hatchling":
+                    /* Abilities
+                     * Slot 1: Peck     | Slicing Wind
+                     * Slot 2: Squawk   | Adrenaline Rush
+                     * Slot 3: Flock    | Lift-Off
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lift-Off"),
+                        new AandC("Peck"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Squawk"),
+                        new AandC("Adrenaline Rush"),
+                        new AandC("Flock"),
+                    };
+                    break;
+
+                case "Guardian Cub":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Onyx Bite
+                     * Slot 2: Roar             | Wild Winds
+                     * Slot 3: Reckless Strike  | Cyclone
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Onyx Bite"),
+                        new AandC("Roar"),
+                        new AandC("Wild Winds"),
+                        new AandC("Reckless Strike"),
+                    };
+                    break;
+
+                case "Highlands Turkey":
+                case "Plump Turkey":
+                case "Turkey":
+                    /* Abilities
+                     * Slot 1: Peck         | Slicing Wind
+                     * Slot 2: Squawk       | Gobble Strike
+                     * Slot 3: Food Coma    | Flock
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Peck"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Squawk"),
+                        new AandC("Gobble Strike",  () =>speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Food Coma"),
+                        new AandC("Flock"),
+                    };
+                    break;
+
+                case "Ikky":
+                    /* Changelog:
+                     * 2015-01-20: Nocturnal Strike is now only used against blinded enemies - Studio60
+                     * 2015-01-19: Black Claw is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Savage Talon | Quills
+                     * Slot 2: Black Claw   | Nocturnal Strike
+                     * Slot 3: Flock        | Cyclone
+                     * 
+                     * Tactic Information:
+                     * Quills are prioritized after Flock to finish the enemy off
+                     * Flock is used in Black Claw combo
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Black Claw",         () => ! debuff("Black Claw") && hpEnemy > 0.15),
+                        new AandC("Nocturnal Strike",   () => enemyIsBlinded()),
+                        new AandC("Quills",             () => debuff("Black Claw") && debuff("Shattered Defenses")),
+                        new AandC("Flock",              () => debuff("Black Claw")),
+                        new AandC("Savage Talon"),
+                        new AandC("Quills"),
+                    };
+                    break;
+
+                case "Imperial Moth":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Wild Winds
+                     * Slot 2: Cocoon Strike    | Moth Balls
+                     * Slot 3: Moth Dust        | Cyclone
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Wild Winds"),
+                        new AandC("Cocoon Strike"),
+                        new AandC("Moth Balls"),
+                        new AandC("Moth Dust"),
+                    };
+                    break;
+
+                case "Jade Crane Chick":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Thrash
+                     * Slot 2: Hawk Eye     | Jadeskin
+                     * Slot 3: Cyclone      | Flock
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Hawk Eye",       () => ! buff("Hawk Eye")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Thrash"),
+                        new AandC("Jadeskin"),
+                        new AandC("Flock"),
+                    };
+                    break;
+
+                case "Ji-Kun Hatchling":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Peck
+                     * Slot 2: Wild Winds   | Acidic Goo
+                     * Slot 3: Flock        | Caw
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Acidic Goo",     () => ! debuff("Acidic Goo")),
+                        new AandC("Slicing Wind",   () => ! debuff("Wild Winds")),
+                        new AandC("Peck"),
+                        new AandC("Wild Winds"),
+                        new AandC("Flock"),
+                        new AandC("Caw"),
+                    };
+                    break;
+
+                case "Kaliri Hatchling":
+                    /* Changelog:
+                     * 2015-01-20: Nocturnal Strike is now checking for all blindness effects - Studio60
+                     * 2015-01-19: Nocturnal Strike is now sometimes used without the enemy being blinded - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Peck             | Quills
+                     * Slot 2: Wild Winds       | Hawk Eye
+                     * Slot 3: Nocturnal Strike | Predatory Strike
+                     * 
+                     * Tactic Information:
+                     * Predatory Strike is used as a finisher
+                     * 
+                     * TODO: Nocturnal Strike should be used more often, if no team pet can cause Blindness
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Nocturnal Strike",   () => enemyIsBlinded()),
+                        new AandC("Wild Winds",         () => ! debuff("Wild Winds")),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Peck"),
+                        new AandC("Quills"),
+                    };
+                    break;
+
+                case "Mechanical Axebeak":
+                    /* Changelog:
+                     * 2015-01-20: Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Haywire is now used whenever it is strong against an enemy, not only if the enemy is a critter - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Alpha Strike     | Peck
+                     * Slot 2: Hawk Eye         | Haywire
+                     * Slot 3: Decoy            | Lift-Off
+                     * 
+                     * Tactic Information:
+                     * Haywire is only used against Critters
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Lift-Off",       () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Hawk Eye",       () => ! buff("Hawk Eye")),
+                        new AandC("Haywire",        () => strong("Haywire")),
+                        new AandC("Decoy",          () => ! buff("Decoy")),
+                        new AandC("Lift-Off"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Peck"),
+                    };
+                    break;
+
+                case "Miniwing":
+                    /* Abilities
+                     * Slot 1: Peck             | Quills
+                     * Slot 2: Shriek           | Cyclone
+                     * Slot 3: Nocturnal Strike | Predatory Strike
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Shriek",             () => ! debuff("Attack Reduction")),
+                        new AandC("Peck"),
+                        new AandC("Quills"),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Predatory Strike"),
+                    };
+                    break;
+
+                case "Pterrordax Hatchling":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Flyby
+                     * Slot 2: Ancient Blessing | Apocalypse
+                     * Slot 3: Lift-Off         | Feign Death
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ancient Blessing",   () => !buff("Ancient Blessing") || hp < 0.75 ),
+                        new AandC("Lift-Off"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Flyby"),
+                        new AandC("Apocalypse"),
+                        new AandC("Feign Death"),
+                    };
+                    break;
+
+                case "Royal Moth":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Slicing Wind | Alpha Strike
+                     * Slot 2: Counterspell | Hawk Eye
+                     * Slot 3: Moth Dust    | Predatory Strike
+                     * 
+                     * TODO: Use Counterspell selectively
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Counterspell",       () => speed > speedEnemy),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Moth Dust"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Alpha Strike"),
+                    };
+                    break;
+
+                case "Royal Peacock":
+                    /* Changelog:
+                     * 2015-01-19: Rain Dance is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Quills           | Savage Talon
+                     * Slot 2: Dazzling Dance   | Arcane Storm
+                     * Slot 3: Rain Dance       | Feign Death
+                     * 
+                     * TODO: Feign Death needs to check for living team pets
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Dazzling Dance",     () => ! buff("Dazzling Dance")),
+                        new AandC("Arcane Storm"),
+                        new AandC("Rain Dance",         () => ! buff("Rain Dance") && hp < 0.8 && hpEnemy > 0.15),
+                        new AandC("Quills"),
+                        new AandC("Savage Talon"),
+                        new AandC("Feign Death"),
+                    };
+                    break;
+
+                case "Rustberg Gull":
+                case "Sandy Petrel":
+                case "Sea Gull":
+                    /* Abilities 
+                     * Slot 1: Slicing Wind | Thrash
+                     * Slot 2: Cyclone      | Adrenaline Rush
+                     * Slot 3: Hawk Eye     | Lift-Off
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Adrenaline Rush",    () => ! buff("Adrenaline")),
+                        new AandC("Lift-Off"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Thrash"),
+                    };
+                    break;
+
+                case "Sentinel's Companion":
+                    /* Changelog:
+                     * 2015-01-20: Nocturnal Strike is now checking for all blindness effects - Studio60
+                     *             Nocturnal Strike is now used with a higher priority - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Peck             | Dark Talon
+                     * Slot 2: Nocturnal Strike | Soulrush
+                     * Slot 3: Moonfire         | Ethereal
+                     */
+                    // ethereal: can always dodge shouldIHide attacks
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Ethereal",           () => shouldIHide),
+                        new AandC("Nocturnal Strike",   () => enemyIsBlinded()),
+                        new AandC("Soulrush"),
+                        new AandC("Moonfire"),
+                        new AandC("Nocturnal Strike"),
+                        new AandC("Peck"),
+                        new AandC("Dark Talon"),
+                    };
+                    break;
+
+                case "Shadow Sporebat":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Slicing Wind     | Shadow Stash
+                     * Slot 2: Creeping Fungus  | Leech Seed
+                     * Slot 3: Spore Shrooms    | Barbed Stinger
+                     */
+                    // pretty basic tactic
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Creeping Fungus",    () => ! debuff("Creeping Fungus")),
+                        new AandC("Leech Seed",         () => ! debuff("Leech Seed")),
+                        new AandC("Spore Shrooms",      () => ! debuff("Spore Shrooms")),
+                        new AandC("Barbed Stinger"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Shadow Slash"),
+                    };
+                    break;
+
+                case "Sky Fry":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Bite             | Arcane Blast
+                     * Slot 2: Vicious Slice    | Alpha Strike
+                     * Slot 3: Tail Sweep       | Shadow Shock
+                     */
+                    // six different attack types
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Vicious Slice",  () => strong("Vicious Slice")),
+                        new AandC("Alpha Strike",   () => strong("Alpha Strike")),
+                        new AandC("Tail Sweep",     () => strong("Tail Sweep")),
+                        new AandC("Shadow Shock",   () => strong("Shadow Shock")),
+                        new AandC("Bite",           () => strong("Bite")),
+                        new AandC("Arcane Blast",   () => strong("Arcane Blast")),
+                        new AandC("Bite"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Vicious Slice"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Tail Sweep"),
+                        new AandC("Shadow Shock"),
+                    };
+                    break;
+
+                case "Skywisp Moth":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Reckless Strike
+                     * Slot 2: Cocoon Strike    | Counterspell
+                     * Slot 3: Moth Dust        | Call Lightning
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Call Lightning"),
+                        new AandC("Counterspell",       () =>  speed > speedEnemy ),
+                        new AandC("Cocoon Strike"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Reckless Strike"),
+                        new AandC("Moth Dust"),
+                    };
+                    break;
+
+                case "Stormwing":
+                    /* Changelog:
+                     * 2015-01-20: Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Alpha Strike     | Quills
+                     * Slot 2: Call Lightning   | Lift-Off
+                     * Slot 3: Thunderbolt      | Flock
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Lift-Off",       () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Call Lightning", () => ! weather("Lightning Storm")),
+                        new AandC("Thunderbolt"),
+                        new AandC("Lift-Off"),
+                        new AandC("Flock"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Quills"),
+                    };
+                    break;
+
+                case "Sunfire Kaliri":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Deep Burn    | Fire Quills
+                     * Slot 2: Shriek       | Scorched Earth
+                     * Slot 3: Cauterize    | Predatory Strike
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Shriek",             () => ! debuff("Attack Reduction")),
+                        new AandC("Scorched Earth",     () => ! weather("Scorched Earth")),
+                        new AandC("Cauterize",          () => hp < 0.75),
+                        new AandC("Deep Burn"),
+                        new AandC("Fire Quills"),
+                    };
+                    break;
+
+                case "Swamplighter Firefly":
+                    /* Changelog:
+                     * 2015-01-20: Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Puncture Wound is now checking for all poison effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Barbed Stinger   | Alpha Strike
+                     * Slot 2: Lift-Off         | Puncture Wound
+                     * Slot 3: Flyby            | Nimbus
+                     */
+                    // nimbus: don't need accuracy increase
+                    // lift-off: used defensively if we are fast enough
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Lift-Off",       () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Puncture Wound", () => enemyIsPoisoned()),
+                        new AandC("Flyby",          () => ! debuff("Weakened Defenses")),
+                        new AandC("Barbed Stinger"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Lift-Off"),
+                        new AandC("Nimbus"),
+                    };
+                    break;
+
+                case "Teroclaw Hatchling":
+                    /* Changelog:
+                     * 2015-01-20: Dodge is now used to hide from huge attacks if it is faster or both bets have equal speed - Studio60
+                     * 2015-01-19: Nature's Ward conditions have been updated (Studio60)
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Claw     | Alpha Strike
+                     * Slot 2: Hawk Eye | Dodge
+                     * Slot 3: Ravage   | Nature's Ward
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Dodge",          () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Hawk Eye",       () => ! buff("Hawk Eye")),
+                        new AandC("Ravage",         () => (! famEnemy(PF.Critter) && hp < 0.2)  || (famEnemy(PF.Critter) && hp < 0.4)),
+                        new AandC("Nature's Ward",  () => hp < 0.9 && ! famEnemy(PF.Aquatic) && ! buff("Nature's Ward")),
+                        new AandC("Claw"),
+                        new AandC("Alpha Strike"),
+                    };
+                    break;
+
+                case "Tiny Flamefly":
+                    /* Abilities
+                     * Slot 1: Burn     | Alpha Strike
+                     * Slot 2: Immolate | Hiss
+                     * Slot 3: Swarm    | Adrenaline Rush
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burn"),
+                        new AandC("Alpha Strike"),
+                        new AandC("Immolate"),
+                        new AandC("Hiss"),
+                        new AandC("Swarm"),
+                        new AandC("Adrenaline Rush"),
+                    };
+                    break;
+
+                case "Tiny Sporebat":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Shadow Slash
+                     * Slot 2: Creeping Fungus  | Leech Seed
+                     * Slot 3: Spore Shrooms    | Confusing Sting
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Slicing Wind"),
+                        new AandC("Shadow Slash"),
+                        new AandC("Creeping Fungus"),
+                        new AandC("Leech Seed"),
+                        new AandC("Spore Shrooms"),
+                        new AandC("Confusing Sting"),
+                    };
+                    break;
+
+                case "Tuskarr Kite":
+                    /* Abilities
+                     * Slot 1: Slicing Wind | Frost Shock
+                     * Slot 2: Wild Winds   | Cyclone
+                     * Slot 3: Flyby        | Reckless Strike
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () =>     ! debuff("Cyclone")),
+                        new AandC("Slicing Wind"),
+                        new AandC("Frost Shock"),
+                        new AandC("Wild Winds"),
+                        new AandC("Flyby"),
+                        new AandC("Reckless Strike"),
+                    };
+                    break;
+
+                case "Umbrafen Spore":
+                    /* Changelog:
+                     * 2015-01-20: Spore Shrooms is no longer recast too early - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Confusing Sting  | Creeping Fungus
+                     * Slot 2: Spiked Skin      | Blinding Powder
+                     * Slot 3: Spore Shrooms    | Explode
+                     * 
+                     * TODO: Explode needs to check if a backup pet is available
+                     */
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Explode",            () => hp < 0.1),
+                        new AandC("Spiked Skin",        () => ! buff("Spiked Skin")),
+                        new AandC("Blinding Powder"),
+                        new AandC("Spore Shrooms",      () => ! debuff("Spore Shrooms")),
+                        new AandC("Confusing Sting"),
+                        new AandC("Creeping Fungus"),
+                    };
+                    break;
+
+                case "Veilwatcher Hatchling":
+                    /* Changelog:
+                     * 2015-01-20: Nocturnal Strike is now checking for all blindness effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Peck             | Quills
+                     * Slot 2: Wild Winds       | Flock
+                     * Slot 3: Nocturnal Strike | Predatory Strike
+                     */
+                    // nocturnal strike: only if enemy is blinded
+                    flying_abilities = new List<AandC>() {
+                        new AandC("Predatory Strike",   () => hpEnemy < 0.25),
+                        new AandC("Wild Winds",         () => ! debuff("Wild Winds")),
+                        new AandC("Nocturnal Strike",   () => enemyIsBlinded()),
+                        new AandC("Flock",              () => ! debuff("Shattered Defenses")),
+                        new AandC("Peck"),
+                        new AandC("Quills"),
+                    };
+                    break;
+
+                case "Waterfly":
+                    /* Abilities
+                     * Slot 1: Barbed Stinger   | Alpha Strike
+                     * Slot 2: Healing Stream   | Puncture Wound
+                     * Slot 3: Lift-Off         | Dodge
+                     */
+                    flying_abilities = new List<AandC>() 
+                    {
+                        new AandC("Healing Stream",     () => hp < 0.7),
+                        new AandC("Lift-Off"),
+                        new AandC("Dodge"),
+                        new AandC("Barbed Stinger",     () => ! debuff("Poisoned")),
+                        new AandC("Alpha Strike",       () => speed > speedEnemy),
+                        new AandC("Puncture Wound",     () => debuff("Poisoned")),
+                        new AandC("Barbed Stinger"),
+                        new AandC("Alpha Strike"),
+                    };
+                    break;                
+
+                default:
+                    ////////////////////////
+                    // Unknown Flying Pet //
+                    ////////////////////////
+                    Logger.Alert("Unknown flying pet: " + petName);
+                    flying_abilities = null;
+                    break;
             }
+
             return flying_abilities;
         }
     }

--- a/Prosto_Pets/Pets/Humanoid.cs
+++ b/Prosto_Pets/Pets/Humanoid.cs
@@ -24,304 +24,651 @@ namespace Prosto_Pets
 
             List<AandC> humanoid_abilities;
 
-
-////////////
-// GNOMES //
-////////////
-if( petName == "Father Winter's Helper" || petName == "Winter's Little Helper" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Snowball" 		),	// Slot 1
-			new AandC( "Ice Lance" 		),	// Slot 1
-			new AandC( "Call Blizzard" 	),	// Slot 2
-			new AandC( "Eggnog" 			),	// Slot 2
-			new AandC( "Ice Tomb" 		),	// Slot 3
-			new AandC( "Gift of Winter's Veil"),	// Slot 3
-		}
-//////////////
-// HOPLINGS //
-//////////////
-;else if(petName == "Feral Vermling" || petName == "Hopling" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Crush" 			),	// Slot 1
-			new AandC( "Tongue Lash" 	),	// Slot 1
-			new AandC( "Sticky Goo" 		),	// Slot 2
-			new AandC( "Poison Lash" 	),	// Slot 2
-			new AandC( "Backflip" 		),	// Slot 3
-			new AandC( "Dreadful Breath" ),	// Slot 3
-		}
-////////////
-// HUMANS //
-////////////
-// None able to battle
-
-//////////
-// IMPS //
-//////////
-;else if(petName == "Corefire Imp" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Rush", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 1
-			new AandC( "Immolation", () => 		! buff("Immolation") ),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Flamethrower" 	),	// Slot 2
-			new AandC( "Cauterize" 		),	// Slot 3
-			new AandC( "Wild Magic" 		),	// Slot 3
-		}
-;else if(petName == "Fiendish Imp" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Rush", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 3
-			new AandC( "Immolation", () => 		! buff("Immolation") ),	// Slot 2
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Sear Magic"		),	// Slot 1
-			new AandC( "Flamethrower" 	),	// Slot 2
-			new AandC( "Nether Gate" 	),	// Slot 3
-		}
-;else if(petName == "Gregarious Grell" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Immolate", () => 		! debuff("Immolate") ),	// Slot 2
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Phase Shift" 	),	// Slot 2
-			new AandC( "Cauterize" 		),	// Slot 3
-			new AandC( "Sear Magic" 		),	// Slot 3
-		}
-////////////-
-// MOONKIN //
-////////////-
-;else if(petName == "Moonkin Hatchling" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Solar Beam" 		),	// Slot 1
-			new AandC( "Entangling Roots"),	// Slot 2
-			new AandC( "Clobber" 		),	// Slot 2
-			new AandC( "Moonfire" 		),	// Slot 3
-		}
-////////////-
-// MURLOCS //
-////////////-
-;else if(petName == "Deathy" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Deep Breath" 	),	// Slot 1
-			new AandC( "Scorched Earth" 	),	// Slot 2
-			new AandC( "Call Darkness" 	),	// Slot 2
-			new AandC( "Clobber" 		),	// Slot 3
-			new AandC( "Roar" 			),	// Slot 3
-		}
-;else if(petName == "Grunty" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Gauss Rifle" 	),	// Slot 1
-			new AandC( "U-238 Rounds" 	),	// Slot 1
-			new AandC( "Stimpack" 		),	// Slot 2
-			new AandC( "Shield Block" 	),	// Slot 2
-			new AandC( "Launch" 			),	// Slot 3
-			new AandC( "Lock-On" 		),	// Slot 3
-		}
-;else if(petName == "Gurky" || petName == "Lurky" || petName == "Murki" || petName == "Murky" || petName == "Terky" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Flank" 			),	// Slot 1
-			new AandC( "Acid Touch" 		),	// Slot 2
-			new AandC( "Lucky Dance" 	),	// Slot 2
-			new AandC( "Clobber" 		),	// Slot 3
-			new AandC( "Stampede" 		),	// Slot 3
-		}
-;else if(petName == "Murkablo" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Bone Prison" 	),	// Slot 1
-			new AandC( "Agony" 			),	// Slot 2
-			new AandC( "Drain Power" 	),	// Slot 2
-			new AandC( "Blast of Hatred" ),	// Slot 3
-			new AandC( "Scorched Earth" 	),	// Slot 3
-		}
-;else if(petName == "Murkimus the Gladiator" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Shield Block" 	),	// Slot 2
-			new AandC( "Counterstrike" 	),	// Slot 2
-			new AandC( "Heroic Leap" 	),	// Slot 3
-			new AandC( "Haymaker" 		),	// Slot 3
-		}
-//////////
-// ORCS //
-//////////
-// None able to battle
-
-//////////////////-
-// MISCELLANEOUS //
-//////////////////-
-;else if (petName == "Grommloc")            // by Misanthrope
-    humanoid_abilities = new List<AandC>() 
-		{			
-			new AandC( "Giant's Blood",	() =>  ! buff("Attack Boost") || hp < 0.6),	// Slot 3
-			new AandC( "Vicious Slice" 			),	// Slot 1
-			new AandC( "Smash" 			),	// Slot 1
-			new AandC( "Clobber" 			),	// Slot 2
-			new AandC( "Mighty Charge" 		),	// Slot 2
-			new AandC( "Takedown" 			),	// Slot 3
-		}
-;else if(petName == "Anubisath Idol" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Deflection", () =>   shouldIHide	    ),	// Slot 3
-			new AandC( "Sandstorm"  ),	                            // Slot 2
-			new AandC( "Crush" 			),	// Slot 1
-			new AandC( "Demolish"       ),	// Slot 1
-			new AandC( "Stoneskin" 		),	// Slot 2
-			new AandC( "Rupture" 		),	// Slot 3
-		}
-;else if(petName == "Curious Oracle Hatchling" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Super Sticky Goo"),	// Slot 2
-			new AandC( "Aged Yolk" 		),	// Slot 2
-			new AandC( "Backflip" 		),	// Slot 3
-			new AandC( "Dreadful Breath" ),	// Slot 3
-		}
-;else if(petName == "Curious Wolvar Pup" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Snap Trap" 		),	// Slot 2
-			new AandC( "Frenzyheart Brew"),	// Slot 2
-			new AandC( "Whirlwind" 		),	// Slot 3
-			new AandC( "Maul" 			),	// Slot 3
-		}
-;else if(petName == "Flayer Youngling" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Blitz" 			),	// Slot 1
-			new AandC( "Triple Snap" 	),	// Slot 1
-			new AandC( "Focus" 			),	// Slot 2
-			new AandC( "Deflection" 		),	// Slot 2
-			new AandC( "Kick" 			),	// Slot 3
-			new AandC( "Rampage" 		),	// Slot 3
-		}
-;else if(petName == "Harbinger of Flame" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Impale", () => 			hpEnemy < 0.25 ),	// Slot 3 You can also use "2" instead of "LE_BATTLE_PET_ENEMY"
-			new AandC( "Immolate", () => 		! debuff("Immolate") ),	// Slot 2
-			new AandC( "Conflagrate", () => 	debuff("Immolate") || weather("Scorched Earth") ),	// Slot 3
-			new AandC( "Jab" 			),	// Slot 1
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Magma Wave" 	),	// Slot 2
-		}
-;else if(petName == "Harpy Youngling" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Quills" 			),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Flyby" 			),	// Slot 2
-			new AandC( "Counterstrike" 	),	// Slot 2
-			new AandC( "Squawk" 			),	// Slot 3
-		}
-;else if(petName == "Kun-Lai Runt" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Takedown" 		),	// Slot 1
-			new AandC( "Mangle" 			),	// Slot 2
-			new AandC( "Frost Shock" 	),	// Slot 2
-			new AandC( "Rampage" 		),	// Slot 3
-			new AandC( "Deep Freeze" 	),	// Slot 3
-		}
-;else if(petName == "Mini Tyrael" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Holy Sword" 		),	// Slot 1
-			new AandC( "Omnislash" 		),	// Slot 1
-			new AandC( "Holy Justice" 	),	// Slot 2
-			new AandC( "Surge of Light" 	),	// Slot 2
-			new AandC( "Holy Charge" 	),	// Slot 3
-			new AandC( "Restoration" 	),	// Slot 3
-		}
-;else if(petName == "Pandaren Monk" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Jab" 			),	// Slot 1
-			new AandC( "Takedown" 		),	// Slot 1
-			new AandC( "Focus Chi" 		),	// Slot 2
-			new AandC( "Staggered Steps" ),	// Slot 2
-			new AandC( "Fury of 1,000 Fists"),	// Slot 3
-			new AandC( "Blackout Kick" 	),	// Slot 3
-		}
-;else if(petName == "Peddlefeet" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Bow Shot" 		),	// Slot 1
-			new AandC( "Rapid Fire" 		),	// Slot 1
-			new AandC( "Lovestruck" 		),	// Slot 2
-			new AandC( "Perfumed Arrow" 	),	// Slot 2
-			new AandC( "Shot Through The Heart"),	// Slot 3
-			new AandC( "Love Potion" 	),	// Slot 3
-		}
-;else if(petName == "Qiraji Guardling" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Hawk Eye",	()=>	! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Crush" 			),	// Slot 1
-			new AandC( "Whirlwind" 		),	// Slot 1
-			new AandC( "Sandstorm" 		),	// Slot 2
-			new AandC( "Reckless Strike" ),	// Slot 3
-			new AandC( "Blackout Kick" 	),	// Slot 3
-		}
-;else if(petName == "Sporeling Sprout" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Jab" 			),	// Slot 1
-			new AandC( "Charge" 			),	// Slot 1
-			new AandC( "Creeping Fungus" ),	// Slot 2
-			new AandC( "Leech Seed" 		),	// Slot 2
-			new AandC( "Spore Shrooms" 	),	// Slot 3
-			new AandC( "Crouch" 			),	// Slot 3
-		}
-;else if(petName == "Stunted Yeti" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Mangle" 			),	// Slot 2
-			new AandC( "Haymaker" 		),	// Slot 2
-			new AandC( "Rampage" 		),	// Slot 3
-			new AandC( "Bash" 			),	// Slot 3
-		}
-;else if(petName == "Lil' Bad Wolf" )
-	humanoid_abilities = new List<AandC>() 
-		{
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Counterstrike" 	),	// Slot 1
-			new AandC( "Mangle" 			),	// Slot 2
-			new AandC( "Dodge" 			),	// Slot 2
-			new AandC( "Howl" 			),	// Slot 3
-			new AandC( "Pounce" 			),	// Slot 3
-		};
-	
-//////////////////-
-
-            else // Unknown pet
+            switch (petName)
             {
-                Logger.Alert("Unknown humanoid pet: " + petName);
-                return null;
+                case "Anubisath Idol":
+                    /* Abilities
+                     * Slot 1: Crush        | Demolish
+                     * Slot 2: Sandstorm    | Stoneskin
+                     * Slot 3: Deflection   | Rupture
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Deflection",     () => shouldIHide),
+                        new AandC("Sandstorm"),                            
+                        new AandC("Crush"),
+                        new AandC("Demolish"),
+                        new AandC("Stoneskin"),
+                        new AandC("Rupture"),
+                    };
+                    break;
+
+                case "Ashleaf Spriteling":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Poisoned Branch  | Punch
+                     * Slot 2: Solar Beam       | Wild Magic
+                     * Slot 3: Entangling Roots | Thorns
+                     * 
+                     * Tactic Information:
+                     * Solar Beam results in stun which is risky. Use only with enough health
+                     * Entangling Roots should only be used if the match lasts at least 2 more turns
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Solar Beam",         () => weather("Sunny Day") && hp > 0.4),  
+                        new AandC("Wild Magic",         () => ! debuff("Wild Magic")),
+                        new AandC("Thorns",             () => ! buff("Thorns")),  
+                        new AandC("Entangling Roots",   () => hpEnemy > 0.25),  
+                        new AandC("Poisoned Branch"), 
+                        new AandC("Punch"),
+                        new AandC("Solar Beam"),
+                    };
+                    break;
+
+                case "Bonkers":
+                    /* Changelog:
+                     * 2015-01-20: Dodge is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Jab              | Bite
+                     * Slot 2: Going Bonkers!   | Dodge
+                     * Slot 3: Haymaker         | Tornado Punch
+                     * 
+                     * Tactic Information:
+                     * Dodge is used to avoid big hits
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Going Bonkers!",     () => ! buff("Bonkers!")),
+                        new AandC("Dodge",              () => shouldIHide && speed >= speedEnemy), 
+                        new AandC("Haymaker"),
+                        new AandC("Tornado Punch"),
+                        new AandC("Jab"), 
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Corefire Imp":
+                    /* Abilities
+                     * Slot 1: Burn         | Rush
+                     * Slot 2: Immolation   | Flamethrower
+                     * Slot 3: Cauterize    | Wild Magic
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Rush",           () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Immolation",     () => ! buff("Immolation")),
+                        new AandC("Burn"),
+                        new AandC("Flamethrower"),
+                        new AandC("Cauterize"),
+                        new AandC("Wild Magic"),
+                    };
+                    break;
+
+                case "Curious Oracle Hatchling":
+                    /* Abilities
+                     * Slot 1: Punch            | Water Jet
+                     * Slot 2: Super Sticky Goo | Aged Yolk
+                     * Slot 3: Backflip         | Dreadful Breath
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"),
+                        new AandC("Water Jet"),
+                        new AandC("Super Sticky Goo"),
+                        new AandC("Aged Yolk"),
+                        new AandC("Backflip"),
+                        new AandC("Dreadful Breath"),
+                    };
+                    break;
+
+                case "Curious Wolvar Pup":
+                    /* Abilities
+                     * Slot 1: Punch        | Bite
+                     * Slot 2: Snap Trap    | Frenzyheart Brew
+                     * Slot 3: Whirlwind    | Maul
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"),
+                        new AandC("Bite"),
+                        new AandC("Snap Trap"),
+                        new AandC("Frenzyheart Brew"),
+                        new AandC("Whirlwind"),
+                        new AandC("Maul"),
+                    };
+                    break;
+
+                case "Dandelion Frolicker":
+                    /* Changelog:
+                     * 2015-01-20: Frolicking is now used more regularly - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Scratch  | Bite
+                     * Slot 2: Frolick  | Barkskin
+                     * Slot 3: Kick     | Dazzling Dance
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Frolick",        () => ! buff("Frolicking")), 
+                        new AandC("Dazzling Dance", () => ! buff("Dazzling Dance")),  
+                        new AandC("Barkskin",       () => ! buff("Barkskin")),  
+                        new AandC("Kick",           () => speed > speedEnemy),  
+                        new AandC("Scratch"), 
+                        new AandC("Bite"),
+                    };
+                    break;
+
+                case "Deathy":
+                    /* Abilities
+                     * Slot 1: Punch            | Deep Breath
+                     * Slot 2: Scorched Earth   | Call Darkness
+                     * Slot 3: Clobber          | Roar
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"),
+                        new AandC("Deep Breath"),
+                        new AandC("Scorched Earth"),
+                        new AandC("Call Darkness"),
+                        new AandC("Clobber"),
+                        new AandC("Roar"),
+                    };
+                    break;
+
+                case "Father Winter's Helper":
+                case "Winter's Little Helper":
+                    /* Abilities
+                     * Slot 1: Snowball         | Ice Lance
+                     * Slot 2: Call Blizzard    | Eggnog
+                     * Slot 3: Ice Tomb         | Gift of Winter's Veil
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Snowball"),
+                        new AandC("Ice Lance"),
+                        new AandC("Call Blizzard"),
+                        new AandC("Eggnog"),
+                        new AandC("Ice Tomb"),
+                        new AandC("Gift of Winter's Veil"),  
+                    };
+                    break;
+
+                case "Feral Vermling":
+                case "Hopling":
+                    /* Abilities
+                     * Slot 1: Crush        | Tongue Lash
+                     * Slot 2: Sticky Goo   | Poison Lash
+                     * Slot 3: Backflip     | Dreadful Breath
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Crush"),
+                        new AandC("Tongue Lash"),
+                        new AandC("Sticky Goo"),
+                        new AandC("Poison Lash"),
+                        new AandC("Backflip"),
+                        new AandC("Dreadful Breath"),
+                    };
+                    break;
+
+                case "Fiendish Imp":
+                    /* Abilities
+                     * Slot 1: Burn         | Sear Magic
+                     * Slot 2: Immolation   | Flamethrower
+                     * Slot 3: Rush         | Nether Gate
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Rush",           () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Immolation",     () => ! buff("Immolation")),
+                        new AandC("Burn"),
+                        new AandC("Sear Magic"),
+                        new AandC("Flamethrower"),
+                        new AandC("Nether Gate"),
+                    };
+                    break;
+
+                case "Flayer Youngling":
+                    /* Abilities
+                     * Slot 1: Blitz    | Triple Snap
+                     * Slot 2: Focus    | Deflection
+                     * Slot 3: Kick     | Rampage
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Blitz"),
+                        new AandC("Triple Snap"),
+                        new AandC("Focus"),
+                        new AandC("Deflection"),
+                        new AandC("Kick"),
+                        new AandC("Rampage"),
+                    };
+                    break;
+
+                case "Gregarious Grell":
+                    /* Abilities
+                     * Slot 1: Punch        | Burn
+                     * Slot 2: Immolate     | Phase Shift
+                     * Slot 3: Cauterize    | Sear Magic
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Immolate",       () => ! debuff("Immolate")),
+                        new AandC("Punch"),
+                        new AandC("Burn"),
+                        new AandC("Phase Shift"),
+                        new AandC("Cauterize"),
+                        new AandC("Sear Magic"),
+                    };
+                    break;
+
+                case "Grommloc":
+                    /* Changelog
+                     * 2015-01-12: Initial Tactic by Misanthrope
+                     * 
+                     * Abilities
+                     * Slot 1: Vicious Slice    | Smash
+                     * Slot 2: Clobber          | Mighty Charge
+                     * Slot 3: Giant's Blood    | Takedown
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {           
+                        new AandC("Giant's Blood",  () => ! buff("Attack Boost") || hp < 0.6),
+                        new AandC("Vicious Slice"),
+                        new AandC("Smash"),
+                        new AandC("Clobber"),
+                        new AandC("Mighty Charge"),
+                        new AandC("Takedown"),
+                    };
+                    break;
+
+                case "Grunty":
+                    /* Abilities
+                     * Slot 1: Gauss Rifle  | U-238 Rounds
+                     * Slot 2: Stimpack     | Shield Block
+                     * Slot 3: Launch       | Lock-On
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Gauss Rifle"),
+                        new AandC("U-238 Rounds"),
+                        new AandC("Stimpack"),
+                        new AandC("Shield Block"),
+                        new AandC("Launch"),
+                        new AandC("Lock-On"),
+                    };
+                    break;
+
+                case "Gurky":
+                case "Lurky":
+                case "Murki":
+                case "Murky":
+                case "Terky":
+                    /* Abilities
+                     * Slot 1: Punch        | Flank
+                     * Slot 2: Acid Touch   | Lucky Dance
+                     * Slot 3: Clobber      | Stampede
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"),
+                        new AandC("Flank"),
+                        new AandC("Acid Touch"),
+                        new AandC("Lucky Dance"),
+                        new AandC("Clobber"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Harbinger of Flame":
+                    /* Abilities
+                     * Slot 1: Jab          | Burn
+                     * Slot 2: Magma Wave   | Immolate
+                     * Slot 3: Impale       | Conflagrate
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Impale",         () => hpEnemy < 0.25 ),
+                        new AandC("Immolate",       () => ! debuff("Immolate")),
+                        new AandC("Conflagrate",    () => debuff("Immolate") || weather("Scorched Earth")),
+                        new AandC("Jab"),
+                        new AandC("Burn"),
+                        new AandC("Magma Wave"),
+                    };
+                    break;
+
+                case "Harpy Youngling":
+                    /* Abilities
+                     * Slot 1: Quills   | Slicing Wind
+                     * Slot 2: Flyby    | Counterstrike
+                     * Slot 3: Squawk   | Lift-Off
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Lift-Off"),
+                        new AandC("Quills"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Flyby"),
+                        new AandC("Counterstrike"),
+                        new AandC("Squawk"),
+                    };
+                    break;
+
+                case "Kun-Lai Runt":
+                    /* Abilities
+                     * Slot 1: Thrash   | Takedown
+                     * Slot 2: Mangle   | Frost Shock
+                     * Slot 3: Rampage  | Deep Freeze
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Thrash"),
+                        new AandC("Takedown"),
+                        new AandC("Mangle"),
+                        new AandC("Frost Shock"),
+                        new AandC("Rampage"),
+                        new AandC("Deep Freeze"),
+                    };
+                    break;
+
+                case "Lil' Bad Wolf":
+                    /* Abilities
+                     * Slot 1: Claw     | Counterstrike
+                     * Slot 2: Mangle   | Dodge
+                     * Slot 3: Howl     | Pounce
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Counterstrike"),
+                        new AandC("Mangle"),
+                        new AandC("Dodge"),
+                        new AandC("Howl"),
+                        new AandC("Pounce"),
+                    };
+                    break;
+
+                case "Mini Tyrael":
+                    /* Abilities
+                     * Slot 1: Holy Sword   | Omnislash
+                     * Slot 2: Holy Justice | Surge of Light
+                     * Slot 3: Holy Charge  | Restoration
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Holy Sword"),
+                        new AandC("Omnislash"),
+                        new AandC("Holy Justice"),
+                        new AandC("Surge of Light"),
+                        new AandC("Holy Charge"),
+                        new AandC("Restoration"),
+                    };
+                    break;
+
+                case "Moonkin Hatchling":
+                    /* Abilities
+                     * Slot 1: Punch            | Solar Beam
+                     * Slot 2: Entangling Roots | Clobber
+                     * Slot 3: Cyclone          | Moonfire
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Punch"),
+                        new AandC("Solar Beam"),
+                        new AandC("Entangling Roots"),
+                        new AandC("Clobber"),
+                        new AandC("Moonfire"),
+                    };
+                    break;
+
+                case "Murkablo":
+                    /* Abilities
+                     * Slot 1: Burn             | Bone Prison 
+                     * Slot 2: Agony            | Drain Power
+                     * Slot 3: Blast of Hatred  | Scorched Earth
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burn"),
+                        new AandC("Bone Prison"),
+                        new AandC("Agony"),
+                        new AandC("Drain Power"),
+                        new AandC("Blast of Hatred"),
+                        new AandC("Scorched Earth"),
+                    };
+                    break;
+
+                case "Murkimus the Gladiator":
+                    /* Abilities
+                     * Slot 1: Punch        | Flurry
+                     * Slot 2: Shield Block | Counterstrike
+                     * Slot 3: Heroic Leap  | Haymaker
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"),
+                        new AandC("Flurry"),
+                        new AandC("Shield Block"),
+                        new AandC("Counterstrike"),
+                        new AandC("Heroic Leap"),
+                        new AandC("Haymaker"),
+                    };
+                    break;
+
+                case "Pandaren Monk":
+                    /* Abilities
+                     * Slot 1: Jab                  | Takedown
+                     * Slot 2: Focus Chi            | Staggered Steps
+                     * Slot 3: Fury of 1,000 Fists  | Blackout Kick
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Jab"),
+                        new AandC("Takedown"),
+                        new AandC("Focus Chi"),
+                        new AandC("Staggered Steps"),
+                        new AandC("Fury of 1,000 Fists"),
+                        new AandC("Blackout Kick"),
+                    };
+                    break;
+
+                case "Peddlefeet":
+                    /* Abilities
+                     * Slot 1: Bow Shot                 | Rapid Fire
+                     * Slot 2: Lovestruck               | Perfumed Arrow
+                     * Slot 3: Shot Through The Heart   | Love Potion
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bow Shot"),
+                        new AandC("Rapid Fire"),
+                        new AandC("Lovestruck"),
+                        new AandC("Perfumed Arrow"),
+                        new AandC("Shot Through The Heart"), 
+                        new AandC("Love Potion"),
+                    };
+                    break;
+
+                case "Qiraji Guardling":
+                    /* Abilities
+                     * Slot 1: Crush            | Whirlwind
+                     * Slot 2: Hawk Eye         | Sandstorm
+                     * Slot 3: Reckless Strike  | Blackout Kick
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")), 
+                        new AandC("Crush"),
+                        new AandC("Whirlwind"),
+                        new AandC("Sandstorm"),
+                        new AandC("Reckless Strike"),
+                        new AandC("Blackout Kick"),
+                    };
+                    break;
+
+                case "Rotten Little Helper":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Club | Ice Lance
+                     * Slot 2: Booby-Trapped Presents | Ice Tomb
+                     * Slot 3: Greench's Gift | Call Blizzard
+                     * 
+                     * Tactic Information:
+                     * Ice Tomb needs 3 turns to hit so it is used when the enemy is going to be alive for a bit
+                     * 
+                     * TODO: Booby-Trapped Presents needs to check how many enemies there are
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Ice Tomb",                   () => hpEnemy > 0.6),
+                        new AandC("Greench's Gift"),  
+                        new AandC("Call Blizzard",              () => ! debuff("Blizzard")),
+                        new AandC("Club"),
+                        new AandC("Ice Lance"),
+                        new AandC("Booby-Trapped Presents"),  
+                    };
+                    break;
+
+                case "Sporeling Sprout":
+                    /* Abilities
+                     * Slot 1: Jab              | Charge
+                     * Slot 2: Creeping Fungus  | Leech Seed
+                     * Slot 3: Spore Shrooms    | Crouch
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Jab"),
+                        new AandC("Charge"),
+                        new AandC("Creeping Fungus"),
+                        new AandC("Leech Seed"),
+                        new AandC("Spore Shrooms"),
+                        new AandC("Crouch"),
+                    };
+                    break;
+
+                case "Stunted Yeti":
+                    /* Abilities
+                     * Slot 1: Thrash   | Punch
+                     * Slot 2: Mangle   | Haymaker
+                     * Slot 3: Rampage  | Bash
+                     */
+                    humanoid_abilities = new List<AandC>() 
+                    {
+                        new AandC("Thrash"),
+                        new AandC("Punch"),
+                        new AandC("Mangle"),
+                        new AandC("Haymaker"),
+                        new AandC("Rampage"),
+                        new AandC("Bash"),
+                    };
+                    break;
+
+                case "Ore Eater":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Acid Touch   | Punch
+                     * Slot 2: Shell Armor  | Spiny Carapace
+                     * Slot 3: Body Slam    | Demolish
+                     * 
+                     * Tactic Information:
+                     * Shell Armor should block knockback damage (Untested)
+                     * 
+                     * TODO: Use Spiny Carapace again on anticipated big hit
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Shell Armor",    () => ! buff("Shell Armor")),
+                        new AandC("Spiny Carapace", () => ! buff("Spiny Carapace")),  
+                        new AandC("Body Slam",      () => buff("Shell Armor")),
+                        new AandC("Demolish"),
+                        new AandC("Acid Touch"),  
+                        new AandC("Punch"),
+                    };
+                    break;
+
+                case "Sister of Temptation":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Shadow Shock     | Agony
+                     * Slot 2: Curse of Doom    | Siphon Life
+                     * Slot 3: Lovestruck   | Haunting Song
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Curse of Doom",  () => ! debuff("Curse of Doom") && hpEnemy > 0.5), 
+                        new AandC("Siphon Life",    () => ! debuff("Siphon Life") && hp < 0.9),  
+                        new AandC("Lovestruck"),  
+                        new AandC("Haunting Song",  () => hp < 0.8),
+                        new AandC("Shadow Shock"),
+                        new AandC("Agony"),
+                    };
+                    break;
+
+                case "Treasure Goblin":
+                    /* Changelog:
+                     * 2015-01-20: Dodge is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     *             Portal is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Coin Toss    | Magic Sword
+                     * Slot 2: Wild Magic   | Sear Magic
+                     * Slot 3: Dodge        | Portal
+                     * 
+                     * TODO: Sear Magic needs to check for negative/positive auras on pet
+                     * TODO: Portal needs to check for alternate pets in team
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Wild Magic",     () => ! debuff("Wild Magic")),
+                        new AandC("Dodge",          () => shouldIHide && speed >= speedEnemy), 
+                        new AandC("Portal",         () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Coin Toss"),
+                        new AandC("Magic Sword"), 
+                        new AandC("Sear Magic"),                      
+                    };
+                    break;
+
+                case "Wretched Servant":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Jab          | Nether Blast
+                     * Slot 2: Consume      | Weakness
+                     * Slot 3: Wild Magic   | Consume Magic
+                     * 
+                     * * TODO: Consume Magic needs to check for negative/positive auras on pet
+                     */
+                    humanoid_abilities = new List<AandC>() {
+                        new AandC("Wild Magic",     () => ! debuff("Wild Magic")),
+                        new AandC("Consume",        () => hp < 0.7), 
+                        new AandC("Weakness",       () => ! debuff("Weakness")),
+                        new AandC("Jab"), 
+                        new AandC("Nether Blast"),
+                        new AandC("Consume Magic"),
+                    };
+                    break;
+
+                default:
+                    //////////////////////////
+                    // Unknown Humanoid Pet //
+                    //////////////////////////
+                    Logger.Alert("Unknown humanoid pet: " + petName);
+                    humanoid_abilities = null;
+                    break;
             }
+
             return humanoid_abilities;
+
+
+
         }
     }
 }

--- a/Prosto_Pets/Pets/Magic.cs
+++ b/Prosto_Pets/Pets/Magic.cs
@@ -24,357 +24,821 @@ namespace Prosto_Pets
 
             List<AandC> magic_abilities;
 
+            switch (petName)
+            {
+                case "Abyssius":
+                    /* Changelog:
+                     * 2015-01-20: Meteor Strike is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Immolation   | Crush
+                     * Slot 2: Flamethrower | Scorched Earth
+                     * Slot 3: Volcano      | Meteor Strike
+                     */
+                    // immolation: horrible first attack..
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Meteor Strike",  () => shouldIHide && speed >= speedEnemy), 
+                        new AandC("Immolation",     () => ! buff("Immolation")),  
+                        new AandC("Scorched Earth", () => ! weather("Scorched Earth")),
+                        new AandC("Volcano",        () => hpEnemy > 0.4),
+                        new AandC("Flamethrower"),
+                        new AandC("Immolation"),  
+                        new AandC("Crush"),
+                    };
+                    break;
+
+                case "Arcane Eye":
+                    /* Abilities
+                     * Slot 1: Focused Beams        | Psychic Blast
+                     * Slot 2: Eyeblast             | Drain Power
+                     * Slot 3: Interrupting Gaze    | Mana Surge
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Focused Beams"),
+                        new AandC("Physic Blast"),
+                        new AandC("Eyeblast"),
+                        new AandC("Drain Power"),
+                        new AandC("Interrupting Gaze"),
+                        new AandC("Mana Surge"),
+                    };
+                    break;
+
+                case "Baneling":
+                    /* Abilities
+                     * Slot 1: Bite                 | Trash
+                     * Slot 2: Centrifugal Hooks    | Adrenal Glands
+                     * Slot 3: Burrow               | Baneling Burst
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Thrash"),
+                        new AandC("Centrifugal Hooks"),
+                        new AandC("Adrenal Glands"),
+                        new AandC("Burrow"),
+                        new AandC("Baneling Burst"),
+                    };
+                    break;
+
+                case "Chaos Pup":
+                    /* Changelog:
+                     * 2015-01-19: Dreadful Breath is only used if pet health is over 40% (up from 0%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Bite | Eyeblast
+                     * Slot 2: Dreadful Breath | Consume Corpse
+                     * Slot 3: Enrage | Nethergate
+                     * 
+                     * TODO: Consume Corpse needs to detect own team status
+                     * TODO: Nether Gate needs to detect enemy team status
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Dreadful Breath",    () => weather("Cleansing Rain") && hp > 0.4),
+                        new AandC("Enrage",             () => ! buff("Enrage")),  
+                        new AandC("Bite"),
+                        new AandC("Eyeblast"),
+                        new AandC("Consume Corpse"),  
+                        new AandC("Nether Gate"), 
+                    };
+                    break;
+
+                case "Coilfang Stalker":
+                    /* Abilities
+                     * Slot 1: Laser            | Focused Beams
+                     * Slot 2: Gravity          | Illusionary Barrier 
+                     * Slot 3: Surge of Power   | Amplify Magic
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Laser"),
+                        new AandC("Focused Beams"),
+                        new AandC("Gravity"),
+                        new AandC("Illusionary Barrier"),
+                        new AandC("Surge of Power"),
+                        new AandC("Amplify Magic"),
+                    };
+                    break;
+
+                case "Darkmoon Eye":
+                    /* Abilities
+                     * Slot 1: Laser            | Focused Beams
+                     * Slot 2: Eyeblast         | Inner Vision
+                     * Slot 3: Darkmoon Curse   | Interrupting Gaze
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Laser"),
+                        new AandC("Focused Beams"),
+                        new AandC("Eyeblast"),
+                        new AandC("Inner Vision"),
+                        new AandC("Darkmoon Curse"),
+                        new AandC("Interrupting Gaze"),
+                    };
+                    break;
+
+                case "Elekk Plushie":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Rawr!        | Cute As A Button
+                     * Slot 2: Nap Time     | Who's The Best Elekk In The Whole World?
+                     * Slot 3: Plushie Rush | Itchin' for a Stitchin'
+                     * 
+                     * Tactic Information
+                     * Doesn't really matter, they have no effect
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Rawr!"),
+                        new AandC("Cute As A Button"),
+                        new AandC("Nap Time"),
+                        new AandC("Who's The Best Elekk In The Whole World?"),
+                        new AandC("Plushie Rush"),
+                        new AandC("Itchin' for a Stitchin'"), 
+                    };
+                    break;
+
+                case "Enchanted Broom":
+                    /* Abilities
+                     * Slot 1: Broom        | Batter
+                     * Slot 2: Sandstorm    | Sweep
+                     * Slot 3: Clean-Up     | Wind-Up
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Broom"),
+                        new AandC("Batter"),
+                        new AandC("Sandstorm"),
+                        new AandC("Sweep"),
+                        new AandC("Clean-Up"),
+                        new AandC("Wind-Up"),
+                    };
+                    break;
+
+                case "Enchanted Lantern":
+                case "Festival Lantern":
+                case "Lunar Lantern":
+                    /* Abilities
+                     * Slot 1: Beam         | Burn
+                     * Slot 2: Illuminate   | Flash
+                     * Slot 3: Soul Ward    | Light
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Beam"),
+                        new AandC("Burn"),
+                        new AandC("Illuminate"),
+                        new AandC("Flash"),
+                        new AandC("Soul Ward"),
+                        new AandC("Light"),
+                    };
+                    break;
+
+                case "Ethereal Soul-Trader":
+                    /* Abilities
+                     * Slot 1: Punch        | Beam
+                     * Slot 2: Soul Ward    | Inner Vision
+                     * Slot 3: Soulrush     | Life Exchange
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Punch"),
+                        new AandC("Beam"),
+                        new AandC("Soul Ward"),
+                        new AandC("Inner Vision"),
+                        new AandC("Soulrush"),
+                        new AandC("Life Exchange"),
+                    };
+                    break;
+
+                case "Eye of Observation":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Arcane Blast | Eyeblast
+                     * Slot 2: Counterspell | Lens Flare
+                     * Slot 3: Blinkstrike  | Powerball
+                     * 
+                     * TODO: Create some decision process for Counterspell
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Lens Flare",     () => ! debuff("Partially Blinded")), 
+                        new AandC("Blinkstrike"), 
+                        new AandC("Powerball"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Eyeblast"),
+                        new AandC("Counterspell",   () => speed > speedEnemy),  
+                    };
+                    break;
+
+                case "Filthling":
+                    /* Abilities
+                     * Slot 1: Dreadful Breath  | Absorb
+                     * Slot 2: Stench           | Expunge
+                     * Slot 3: Corrosion        | Creeping Ooze
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Dreadful Breath"),
+                        new AandC("Absorb"),
+                        new AandC("Stench"),
+                        new AandC("Expunge"),
+                        new AandC("Corrosion"),
+                        new AandC("Creeping Ooze"),
+                    };
+                    break;
+
+                case "Gusting Grimoire":
+                    /* Abilities
+                     * Slot 1: Fel Immolate     | Shadow Shock
+                     * Slot 2: Agony            | Amplify Magic
+                     * Slot 3: Meteor Strike    | Curse of Doom
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Fel Immolate"),
+                        new AandC("Shadow Shock"),
+                        new AandC("Agony"),
+                        new AandC("Amplify Magic"),
+                        new AandC("Meteor Strike"),
+                        new AandC("Curse of Doom"),
+                    };
+                    break;
+
+                case "Harmonious Porcupette":
+                    /* Changelog:
+                     * 2015-01-19: Lens Flare is no longer used if the enemy is "Partially Blinded" - Studio60
+                     * 	           Hibernate is only used if pet health is between 30% and 60% (changed from 40% - 54%) - Studio60
+                     * 	           Hibernate is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     * 	           Tranquility is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Scratch              | Claw
+                     * Slot 2: Celestial Blessing   | Moonfire
+                     * Slot 3: Hibernate            | Tranquility
+                     * 
+                     * TODO: Celestial Blessing needs to check on team pets
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Moonfire",           () => ! weather("Moonlight")),  
+                        new AandC("Hibernate",          () => ! buff("Celestial Blessing") && hp > 0.3 && hp < 0.6 && hpEnemy > 0.15), 
+                        new AandC("Tranquility",        () => hp < 0.8 && ! buff("Tranquility") && hpEnemy > 0.15),  
+                        new AandC("Scratch"), 
+                        new AandC("Claw"),
+                        new AandC("Celestial Blessing"),  
+                    };
+                    break;
+
+                case "Hyjal Wisp":
+                    /* Changelog:
+                     * 2015-01-20: Evanescence is now used to hide from huge attacks it it is faster or if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Feedback     | Arcane Blast
+                     * Slot 2: Evanescence  | Sear Magic
+                     * Slot 3: Wish         | Amplify Magic
+                     * 
+                     * TODO: Sear Magic needs to distinguish positive/negative auras
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Evanescence",    () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Wish",           () => hp < 0.5),
+                        new AandC("Amplify Magic",  () => ! buff("Amplify Magic")),
+                        new AandC("Feedback"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Sear Magic"),  
+                    };
+                    break;  
+
+                case "Jade Oozeling":
+                case "Oily Slimeling":
+                case "Toxic Wasteling":
+                case "Disgusting Oozeling":
+                    /* Abilities
+                     * Slot 1: Ooze Touch   | Absorb
+                     * Slot 2: Corrosion    | Creeping Ooze
+                     * Slot 3: Expunge      | Acidic Goo
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Acidic Goo",     () => ! debuff("Acidic Goo")),
+                        new AandC("Ooze Touch"),
+                        new AandC("Absorb"),
+                        new AandC("Corrosion"),
+                        new AandC("Creeping Ooze"),
+                        new AandC("Expunge"),
+                    };
+                    break;
+
+                case "Jade Owl":
+                    /* Abilities
+                     * Slot 1: Slicing Wind     | Thrash
+                     * Slot 2: Adrenaline Rush  | Hawk Eye
+                     * Slot 3: Lift-Off         | Cyclone
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",            () => ! debuff("Cyclone")),
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Lift-Off"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Thrash"),
+                        new AandC("Adrenaline Rush"),
+                    };
+                    break;
+
+                case "Jade Tiger":
+                    /* Abilities
+                     * Slot 1: Jade Claw    | Pounce
+                     * Slot 2: Rake         | Jadeskin
+                     * Slot 3: Devour       | Prowl
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",     () => hpEnemy < 0.20 ),
+                        new AandC("Jade Claw"),
+                        new AandC("Pounce"),
+                        new AandC("Rake"),
+                        new AandC("Jadeskin"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                /* not on PTR yet
+                case "K'ute":
+                    magic_abilities = new List<AandC>() {
+                        new AandC(""),
+                        new AandC(""),
+                        new AandC(""),
+                        new AandC(""),
+                        new AandC(""),
+                        new AandC(""),
+                    };
+                    break;
+                 */  
+
+                case "Legs":
+                    /* Abilities
+                     * Slot 1: Laser            | Pump
+                     * Slot 2: Surge of Power   | Gravity
+                     * Slot 3: Focused Beams    | Whirlpool
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Laser"),
+                        new AandC("Pump"),
+                        new AandC("Surge of Power"),
+                        new AandC("Gravity"),
+                        new AandC("Focused Beams"),
+                        new AandC("Whirlpool"),
+                    };
+                    break;
+
+                case "Lesser Voidcaller":
+                    /* Abilities
+                     * Slot 1: Shadow Shock     | Nether Blast
+                     * Slot 2: Siphon Life      | Prismatic Barrier
+                     * Slot 3: Curse of Doom    | Drain Power
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Curse of Doom"),
+                        new AandC("Shadow Shock"),
+                        new AandC("Nether Blast"),
+                        new AandC("Siphon Life"),
+                        new AandC("Prismatic Barrier"),
+                        new AandC("Drain Power"),
+                    };
+                    break;
+
+                case "Lil' Leftovers":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Absorb       | Chew
+                     * Slot 2: Stench       | Crouch
+                     * Slot 3: High Fiber   | Food Coma
+                     * 
+                     * TODO: High Fiber needs to distinguis positive/negative auras
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Stench",     () => ! debuff("Stench")),
+                        new AandC("Crouch",     () => ! buff("Crouch")),  
+                        new AandC("Food Coma"),
+                        new AandC("Absorb"),  
+                        new AandC("Chew"),
+                        new AandC("High Fiber"),  
+                    };
+                    break;
+
+                case "Living Fluid":
+                    /* Abilities
+                     * Slot 1: Ooze Touch   | Absorb
+                     * Slot 2: Corrosion    | Acidic Goo
+                     * Slot 3: Expunge      | Evolution
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Acidic Goo",  () => ! debuff("Acidic Goo")),
+                        new AandC("Ooze Touch"),
+                        new AandC("Absorb"),
+                        new AandC("Corrosion"),
+                        new AandC("Expunge"),
+                        new AandC("Evolution"),
+                    };
+                    break;
+
+                case "Lofty Libram":
+                    /* Abilities
+                     * Slot 1: Arcane Blast     | Shadow Shock
+                     * Slot 2: Arcane Explosion | Amplify Magic
+                     * Slot 3: Inner Vision     | Curse of Doom
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Arcane Blast"),
+                        new AandC("Shadow Shock"),
+                        new AandC("Arcane Explosion"),
+                        new AandC("Amplify Magic"),
+                        new AandC("Inner Vision"),
+                        new AandC("Curse of Doom"),
+                    };
+                    break;
+
+                case "Magic Lamp":
+                    /* Abilities
+                     * Slot 1: Beam         | Arcane Blast
+                     * Slot 2: Sear Magic   | Gravity
+                     * Slot 3: Soul Ward    | Wish
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Beam"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Sear Magic"),
+                        new AandC("Gravity"),
+                        new AandC("Soul Ward"),
+                        new AandC("Wish"),
+                    };
+                    break;
+
+                case "Mana Wyrmling":
+                case "Shimmering Wyrmling":
+                    /* Abilities
+                     * Slot 1: Feedback     | Flurry
+                     * Slot 2: Drain Power  | Amplify Magic
+                     * Slot 3: Mana Surge   | Deflection
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Feedback"),
+                        new AandC("Flurry"),
+                        new AandC("Drain Power"),
+                        new AandC("Amplify Magic"),
+                        new AandC("Mana Surge"),
+                        new AandC("Deflection"),
+                    };
+                    break;
+
+                case "Minfernal":
+                    /* Abilities
+                     * Slot 1: Crush            | Immolate
+                     * Slot 2: Immolation       | Extra Plating
+                     * Slot 3: Meteor Strike    | Explode
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Immolation",     () => ! buff("Immolation")),
+                        new AandC("Crush"),
+                        new AandC("Immolate"),
+                        new AandC("Extra Plating"),
+                        new AandC("Meteor Strike"),
+                        new AandC("Explode"),
+                    };
+                    break;
+
+                case "Mini Diablo":
+                    /* Abilities
+                     * Slot 1: Burn             | Blast of Hatred
+                     * Slot 2: Call Darkness    | Agony
+                     * Slot 3: Weakness         | Bone Prison
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Burn"),
+                        new AandC("Blast of Hatred"),
+                        new AandC("Call of Darkness"),
+                        new AandC("Agony"),
+                        new AandC("Weakness"),
+                        new AandC("Bone Prison"),
+                    };
+                    break;
+
+                case "Mini Mindslayer":
+                    /* Abilities
+                     * Slot 1: Eyeblast             | Mana Surge
+                     * Slot 2: Amplify Magic        | Inner Vision
+                     * Slot 3: Interrupting Gaze    | Life Exchange
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Eyeblast"),
+                        new AandC("Mana Surge"),
+                        new AandC("Amplify Magic"),
+                        new AandC("Inner Vision"),
+                        new AandC("Interrupting Gaze"),
+                        new AandC("Life Exchange"),
+                    };
+                    break;
+
+                case "Netherspace Abyssal":
+                    /* Abilities
+                     * Slot 1: Crush            | Immolate
+                     * Slot 2: Immolation       | Explode
+                     * Slot 3: Meteor Strike    | Nether Gate
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Crush"),
+                        new AandC("Immolate"),
+                        new AandC("Immolation"),
+                        new AandC("Explode"),
+                        new AandC("Meteor Strike"),
+                        new AandC("Nether Gate"),
+                    };
+                    break;
+
+                case "Netherspawn, Spawn of Netherspawn":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Nether Blast     | Absorb
+                     * Slot 2: Consume Magic    | Expunge
+                     * Slot 3: Poison Spit      | Creeping Ooze
+                     * 
+                     * TODO: Consume Magic needs to distinguish positive/negative auras
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Expunge"), 
+                        new AandC("Poison Spit",    () => ! debuff("Poisoned")), 
+                        new AandC("Creeping Ooze",  () => ! debuff("Creeping Ooze")),  
+                        new AandC("Nether Blast"),
+                        new AandC("Absorb"),  
+                        new AandC("Consume Magic"),
+                    };
+                    break;
+
+                case "Nordrassil Wisp":
+                    /* Abilities
+                     * Slot 1: Beam         | Light
+                     * Slot 2: Flash        | Arcane Blast
+                     * Slot 3: Soul Ward    | Arcane Explosion
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Beam"),
+                        new AandC("Light"),
+                        new AandC("Flash"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Soul Ward"),
+                        new AandC("Arcane Explosion"),
+                    };
+                    break;
+
+                case "Onyx Panther":
+                    /* Abilities
+                     * Slot 1: Claw         | Onyx Bite
+                     * Slot 2: Stoneskin    | Roar
+                     * Slot 3: Leap         | Stone Rush
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Claw"),
+                        new AandC("Onyx Bite"),
+                        new AandC("Stoneskin"),
+                        new AandC("Roar"),
+                        new AandC("Stone Rush"),
+                    };
+                    break;
+
+                case "Servant of Demidos":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Magic Sword      | Arcane Explosion
+                     * Slot 2: Clean-Up         | Siphon Anima
+                     * Slot 3: Lightning Shield | Soulrush
+                     */
+                    // pretty basic tactic
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Clean-Up",           () => debuff("Decoy") || debuff("Turret")) ,
+                        new AandC("Siphon Anima",       () => hp < 0.75),
+                        new AandC("Lightning Shield",   () => ! buff("Lightning Shield")),  
+                        new AandC("Soulrush"),
+                        new AandC("Magic Sword"), 
+                        new AandC("Arcane Explosion"),
+                    };
+                    break;
+
+                case "Spectral Cub":
+                case "Spectral Tiger Cub":
+                    /* Abilities
+                     * Slot 1: Claw         | Rend
+                     * Slot 2: Evanescence  | Spectral Strike
+                     * Slot 3: Leap         | Prowl
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",               () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Claw"),
+                        new AandC("Rend"),
+                        new AandC("Evanescence"),
+                        new AandC("Spectral Strike"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                case "Spectral Porcupette":
+                    /* Abilities
+                     * Slot 1: Bite                 | Powerball
+                     * Slot 2: Spectral Strike      | Spirit Spikes
+                     * Slot 3: Illusionary Barrier  | Spectral Spine
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bite"),
+                        new AandC("Powerball"),
+                        new AandC("Spectral Strike"),
+                        new AandC("Spirit Spikes"),
+                        new AandC("Illusionary Barrier"),
+                        new AandC("Spectral Spine"),
+                    };
+                    break;
+
+                case "Syd the Squid":
+                    /* Changelog:
+                     * 2015-01-20: Bubble is now used to hide from huge attacks if it is faster or both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Water Jet    | Tidal Wave
+                     * Slot 2: Bubble       | Healing Stream
+                     * Slot 3: Whirlpool    | Cleansing Rain
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Bubble",         () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Healing Stream", () => hp < 0.8),  
+                        new AandC("Whirlpool",      () => hpEnemy > 0.5),  
+                        new AandC("Cleansing Rain", () => ! weather("Cleansing Rain")),
+                        new AandC("Water Jet"),
+                        new AandC("Tidal Wave"),  
+                    };
+                    break;
+
+                case "Trunks":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: When Elekks Fly | Smash
+                     * Slot 2: Ethereal | Moonfire
+                     * Slot 3: Headbutt | Avalanche
+                     */
+                    magic_abilities = new List<AandC>() {
+                        new AandC("Ethereal",           () => shouldIHide), 
+                        new AandC("Moonfire",           () => ! weather("Moonlight")),  
+                        new AandC("Headbutt"),
+                        new AandC("Avalanche"),
+                        new AandC("When Elekks Fly"), 
+                        new AandC("Smash"),
+                    };
+                    break;
+
+                case "Twilight Fiendling":
+                    /* Abilities
+                     * Slot 1: Creepy Chomp     | Rake
+                     * Slot 2: Leap             | Creeping Ooze
+                     * Slot 3: Adrenal Glands   | Siphon Life
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Leap",               () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Creepy Chomp"),
+                        new AandC("Rake"),
+                        new AandC("Creeping Ooze"),
+                        new AandC("Andrenal Glands"),
+                        new AandC("Siphone Life"),
+                    };
+                    break;
+
+                case "Viscidus Globule":
+                    /* Abilities
+                     * Slot 1: Ooze Touch   | Acid Touch
+                     * Slot 2: Weakness     | Poison Spit
+                     * Slot 3: Expunge      | Creeping Ooze
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ooze Touch"),
+                        new AandC("Acid Touch"),
+                        new AandC("Weakness"),
+                        new AandC("Poison Spit"),
+                        new AandC("Expunge"),
+                        new AandC("Creeping Ooze"),
+                    };
+                    break;
+
+                case "Viscous Horror":
+                    /* Abilities
+                     * Slot 1: Ooze Touch   | Absorb
+                     * Slot 2: Corrosion    | Plagued Blood
+                     * Slot 3: Expunge      | Evolution
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ooze Touch"),
+                        new AandC("Absorb"),
+                        new AandC("Corrosion"),
+                        new AandC("Plagued Blood"),
+                        new AandC("Expunge"),
+                        new AandC("Evolution"),
+                    };
+                    break;
+
+                case "Willy":
+                    /* Abilities
+                     * Slot 1: Tongue Lash          | Focused Beams
+                     * Slot 2: Interrupting Gaze    | Eyeblast
+                     * Slot 3: Agony                | Rot
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Tongue Lash"),
+                        new AandC("Focused Beams"),
+                        new AandC("Interrupting Gaze"),
+                        new AandC("Eye Blast"),
+                        new AandC("Agony"),
+                        new AandC("Dark Simulacrum"),
+                    };
+                    break;
+
+                case "Zergling":
+                    /* Abilities
+                     * Slot 1: Bite             | Flank
+                     * Slot 2: Metabolic Boost  | Adrenal Glands
+                     * Slot 3: Consume          | Zergling Rush
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Metabolic Boost", () => speed < speedEnemy && ! buff("Metabolic Boost")),
+                        new AandC("Bite"),
+                        new AandC("Flank"),
+                        new AandC("Adrenal Glands"),
+                        new AandC("Consume"),
+                        new AandC("Zergling Rush"),
+                    };
+                    break;
+
+                case "Zipao Tiger":
+                    /* Abilities
+                     * Slot 1: Onyx Bite    | Pounce
+                     * Slot 2: Rake         | Stoneskin
+                     * Slot 3: Devour       | Prowl
+                     */
+                    magic_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",     () => hpEnemy < 0.20 ),
+                        new AandC("Onyx Bite"),
+                        new AandC("Pounce"),
+                        new AandC("Rake"),
+                        new AandC("Stoneskin"),
+                        new AandC("Prowl"),
+                    };
+                    break;
+
+                default:
+                    ///////////////////////
+                    // Unknown Magic Pet //
+                    ///////////////////////
+                    Logger.Alert("Unknown magic pet: " + petName);
+                    magic_abilities = null;
+                    break;
+            }
+
+            return magic_abilities;
 
 
-////////////
-// DEMONS //
-////////////
-if( petName == "Minfernal" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Immolation", () => 		! buff("Immolation") ),	// Slot 2
-			new AandC( "Crush" 			),	// Slot 1
-			new AandC( "Immolate" 		),	// Slot 1
-			new AandC( "Extra Plating" 	),	// Slot 2
-			new AandC( "Meteor Strike" 	),	// Slot 3
-			new AandC( "Explode" 		),	// Slot 3
-		}
-;else if(petName == "Mini Diablo" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Blast of Hatred" ),	// Slot 1
-			new AandC( "Call of Darkness"),	// Slot 2
-			new AandC( "Agony" 			),	// Slot 2
-			new AandC( "Weakness" 		),	// Slot 3
-			new AandC( "Bone Prison" 	),	// Slot 3
-		}
-;else if(petName == "Twilight Fiendling" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Leap", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Creepy Chomp" 	),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 1
-			new AandC( "Creeping Ooze" 	),	// Slot 2
-			new AandC( "Andrenal Glands" ),	// Slot 3
-			new AandC( "Siphone Life" 	),	// Slot 3
-		}
-;else if(petName == "Lesser Voidcaller" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Curse of Doom" 	),	// Slot 3
-			new AandC( "Shadow Shock" 	),	// Slot 1
-			new AandC( "Nether Blast"	),	// Slot 1
-			new AandC( "Siphon Life"		),	// Slot 2
-			new AandC( "Prismatic Barrier"),	// Slot 2
-			new AandC( "Drain Power" 	),	// Slot 3
-		}
-;else if(petName == "Netherspace Abyssal" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Crush"			),	// Slot 1
-			new AandC( "Immolate"		),	// Slot 1
-			new AandC( "Immolation"		),	// Slot 2
-			new AandC( "Explode"			),	// Slot 2
-			new AandC( "Meteor Strike" 	),	// Slot 3
-			new AandC( "Nether Gate" 	),	// Slot 3
-		}
-////////////////////////
-// JEWELED COMPANIONS //
-////////////////////////
-;else if(petName == "Jade Owl" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Hawk Eye",	() =>		! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-		}
-;else if(petName == "Jade Tiger" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Devour", () => 			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC( "Jade Claw" 		),	// Slot 1
-			new AandC( "Pounce" 			),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 2
-			new AandC( "Jadeskin" 		),	// Slot 2
-			new AandC( "Prowl" 			),	// Slot 3
-		}
-;else if(petName == "Onyx Panther" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Leap", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 3
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Onyx Bite" 		),	// Slot 1
-			new AandC( "Stoneskin" 		),	// Slot 2
-			new AandC( "Roar" 			),	// Slot 2
-			new AandC( "Stone Rush" 		),	// Slot 3
-		}
-;else if(petName == "Zipao Tiger" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Devour", () => 			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC( "Onyx Bite" 		),	// Slot 1
-			new AandC( "Pounce" 			),	// Slot 1
-			new AandC( "Rake" 			),	// Slot 2
-			new AandC( "Stoneskin" 		),	// Slot 2
-			new AandC( "Prowl" 			),	// Slot 3
-		}
-////////////////////////
-// LANTERNS && LAMPS //
-////////////////////////
-;else if(petName == "Enchanted Lantern" || petName == "Festival Lantern" || petName == "Lunar Lantern" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Beam" 			),	// Slot 1
-			new AandC( "Burn" 			),	// Slot 1
-			new AandC( "Illuminate" 		),	// Slot 2
-			new AandC( "Flash" 			),	// Slot 2
-			new AandC( "Soul Ward" 		),	// Slot 3
-			new AandC( "Light" 			),	// Slot 3
-		}
-;else if(petName == "Magic Lamp" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Beam" 			),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Sear Magic" 		),	// Slot 2
-			new AandC( "Gravity" 		),	// Slot 2
-			new AandC( "Soul Ward" 		),	// Slot 3
-			new AandC( "Wish" 			),	// Slot 3
-		}
-//////////////////////
-// OOZES && SLIMES //
-//////////////////////
-;else if(petName == "Jade Oozeling" || petName == "Oily Slimeling" || petName == "Toxic Wasteling" || petName == "Disgusting Oozeling" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Acidic Goo",  () =>	! debuff("Acidic Goo") ),	// Slot 3
-			new AandC( "Ooze Touch" 		),	// Slot 1
-			new AandC( "Absorb" 			),	// Slot 1
-			new AandC( "Corrosion" 		),	// Slot 2
-			new AandC( "Creeping Ooze" 	),	// Slot 2
-			new AandC( "Expunge" 		),	// Slot 3
-		}
-;else if(petName == "Viscidus Globule" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Ooze Touch" 		),	// Slot 1
-			new AandC( "Acid Touch" 		),	// Slot 1
-			new AandC( "Weakness" 		),	// Slot 2
-			new AandC( "Poison Spit" 	),	// Slot 2
-			new AandC( "Expunge" 		),	// Slot 3
-			new AandC( "Creeping Ooze" 	),	// Slot 3
-		}
-;else if(petName == "Filthling" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Dreadful Breath" ),	// Slot 1
-			new AandC( "Absorb" 			),	// Slot 1
-			new AandC( "Stench" 			),	// Slot 2
-			new AandC( "Expunge" 		),	// Slot 2
-			new AandC( "Corrosion" 		),	// Slot 3
-			new AandC( "Creeping Ooze" 	),	// Slot 3
-		}
-;else if(petName == "Living Fluid" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Acidic Goo",  () =>	! debuff("Acidic Goo") ),	// Slot 2
-			new AandC( "Ooze Touch" 		),	// Slot 1
-			new AandC( "Absorb" 			),	// Slot 1
-			new AandC( "Corrosion" 		),	// Slot 2
-			new AandC( "Expunge" 		),	// Slot 3
-			new AandC( "Evolution"		),	// Slot 3
-		}
-;else if(petName == "Viscous Horror" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Ooze Touch" 		),	// Slot 1
-			new AandC( "Absorb" 			),	// Slot 1
-			new AandC( "Corrosion" 		),	// Slot 2
-			new AandC( "Plagued Blood" 	),	// Slot 2
-			new AandC( "Expunge" 		),	// Slot 3
-			new AandC( "Evolution" 		),	// Slot 3
-		}
-//////////////-
-// WYRMLINGS //
-//////////////-
-;else if(petName == "Mana Wyrmling" || petName == "Shimmering Wyrmling" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Feedback" 		),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Drain Power" 	),	// Slot 2
-			new AandC( "Amplify Magic" 	),	// Slot 2
-			new AandC( "Mana Surge" 		),	// Slot 3
-			new AandC( "Deflection" 		),	// Slot 3
-		}
-//////////////////-
-// MISCELLANEOUS //
-//////////////////-
-;else if(petName == "Arcane Eye" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Focused Beams" 	),	// Slot 1
-			new AandC( "Physic Blast" 	),	// Slot 1
-			new AandC( "Eyeblast" 		),	// Slot 2
-			new AandC( "Drain Power" 	),	// Slot 2
-			new AandC( "Interrupting Gaze"),	// Slot 3
-			new AandC( "Mana Surge" 		),	// Slot 3
-		}
-;else if(petName == "Darkmoon Eye" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Laser" 			),	// Slot 1
-			new AandC( "Focused Beams" 	),	// Slot 1
-			new AandC( "Eyeblast" 		),	// Slot 2
-			new AandC( "Inner Vision" 	),	// Slot 2
-			new AandC( "Darkmoon Curse" 	),	// Slot 3
-			new AandC( "Interrupting Gaze"),	// Slot 3
-		}
-;else if(petName == "Enchanted Broom" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Broom" 			),	// Slot 1
-			new AandC( "Batter" 			),	// Slot 1
-			new AandC( "Sandstorm" 		),	// Slot 2
-			new AandC( "Sweep" 			),	// Slot 2
-			new AandC( "Clean-Up" 		),	// Slot 3
-			new AandC( "Wind-Up" 		),	// Slot 3
-		}
-;else if(petName == "Ethereal Soul-Trader" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Punch" 			),	// Slot 1
-			new AandC( "Beam" 			),	// Slot 1
-			new AandC( "Soul Ward" 		),	// Slot 2
-			new AandC( "Inner Vision" 	),	// Slot 2
-			new AandC( "Soulrush" 		),	// Slot 3
-			new AandC( "Life Exchange" 	),	// Slot 3
-		}
-;else if(petName == "Gusting Grimoire" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Fel Immolate" 	),	// Slot 1
-			new AandC( "Shadow Shock" 	),	// Slot 1
-			new AandC( "Agony" 			),	// Slot 2
-			new AandC( "Amplify Magic" 	),	// Slot 2
-			new AandC( "Meteor Strike" 	),	// Slot 3
-			new AandC( "Curse of Doom" 	),	// Slot 3
-		}
-;else if(petName == "Legs" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Laser" 			),	// Slot 1
-			new AandC( "Pump" 			),	// Slot 1
-			new AandC( "Surge of Power" 	),	// Slot 2
-			new AandC( "Gravity" 		),	// Slot 2
-			new AandC( "Focused Beams" 	),	// Slot 3
-			new AandC( "Whirlpool" 		),	// Slot 3
-		}
-;else if(petName == "Lofty Libram" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Shadow Shock" 	),	// Slot 1
-			new AandC( "Arcane Explosion"),	// Slot 2
-			new AandC( "Amplify Magic" 	),	// Slot 2
-			new AandC( "Inner Vision" 	),	// Slot 3
-			new AandC( "Curse of Doom" 	),	// Slot 3
-		}
-;else if(petName == "Mini Mindslayer" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Eyeblast" 		),	// Slot 1
-			new AandC( "Mana Surge" 		),	// Slot 1
-			new AandC( "Amplify Magic" 	),	// Slot 2
-			new AandC( "Inner Vision" 	),	// Slot 2
-			new AandC( "Interrupting Gaze"),	// Slot 3
-			new AandC( "Life Exchange" 	),	// Slot 3
-		}
-;else if(petName == "Nordrassil Wisp" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Beam" 			),	// Slot 1
-			new AandC( "Light" 			),	// Slot 1
-			new AandC( "Flash" 			),	// Slot 2
-			new AandC( "Arcane Blast" 	),	// Slot 2
-			new AandC( "Soul Ward" 		),	// Slot 3
-			new AandC( "Arcane Explosion"),	// Slot 3
-		}
-;else if(petName == "Spectral Cub" || petName == "Spectral Tiger Cub" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Leap", () => 			speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 3
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Rend" 			),	// Slot 1
-			new AandC( "Evanescence" 	),	// Slot 2
-			new AandC( "Spectral Strike" ),	// Slot 2
-			new AandC( "Prowl" 			),	// Slot 3
-		}
-;else if(petName == "Spectral Porcupette" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Powerball" 		),	// Slot 1
-			new AandC( "Spectral Strike" ),	// Slot 2
-			new AandC( "Spirit Spikes" 	),	// Slot 2
-			new AandC( "Illusionary Barrier" ),	// Slot 3
-			new AandC( "Spectral Spine" 	),	// Slot 3
-		}
-;else if(petName == "Willy" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Tongue Lash" 	),	// Slot 1
-			new AandC( "Focused Beams" 	),	// Slot 1
-			new AandC( "Interrupting Gaze"),	// Slot 2
-			new AandC( "Eye Blast" 		),	// Slot 2
-			new AandC( "Agony" 			),	// Slot 3
-			new AandC( "Dark Simulacrum" ),	// Slot 3
-		}
-;else if(petName == "Coilfang Stalker" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Laser" 			),	// Slot 1
-			new AandC( "Focused Beams" 	),	// Slot 1
-			new AandC( "Gravity"			),	// Slot 2
-			new AandC( "Illusionary Barrier"),	// Slot 2
-			new AandC( "Surge of Power" 	),	// Slot 3
-			new AandC( "Amplify Magic"	),	// Slot 3
-		}
-////////////////////-
-// ZERG COMPANIONS //
-////////////////////-
-;else if(petName == "Baneling" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Centrifugal Hooks"),	// Slot 2
-			new AandC( "Adrenal Glands" 	),	// Slot 2
-			new AandC( "Burrow" 			),	// Slot 3
-			new AandC( "Baneling Burst" 	),	// Slot 3
-		}
-;else if(petName == "Zergling" )
-	magic_abilities = new List<AandC>() 
-		{
-			new AandC( "Metabolic Boost", () =>		speed < speedEnemy && ! buff("Metabolic Boost") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Flank" 			),	// Slot 1
-			new AandC( "Adrenal Glands" 	),	// Slot 2
-			new AandC( "Consume" 		),	// Slot 3
-			new AandC( "Zergling Rush" 	),	// Slot 3
-		};
-//////////////////-
 
-else // Unknown pet
-{
-    Logger.Alert("Unknown magic pet: " + petName);
-    return null;
-}
-return magic_abilities;
         }
     }
 }

--- a/Prosto_Pets/Pets/Mechanical.cs
+++ b/Prosto_Pets/Pets/Mechanical.cs
@@ -24,410 +24,752 @@ namespace Prosto_Pets
 
             List<AandC> mechanical_abilities;
 
-            if (petName == "Iron Starlette")
-                mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Explode",       () =>   hp < 0.1 	),	        // Slot 3 TODO: check the chances to win conventionally
-			new AandC( "Powerball",     () => 	speed <= speedEnemy),	// Slot 2  against Undead
-			new AandC( "Toxic Smoke" ,  () =>   ! buff("Toxic Smoke")			),	// Slot 2
-			new AandC( "Wind-Up",       () =>   ! buff("Wind-Up") 		),	// Slot 1
-			new AandC( "Supercharge",   () =>   shouldIHide ),	            // Slot 2
-			new AandC( "Wind-Up",       () =>   buff("Wind-Up") && buff("Supercharge") && ! shouldIHide ),	// Slot 1
-			new AandC( "Demolish" 			    ),	// Slot 1
-			new AandC( "Powerball"              ),	// Slot 2  against Undead
-		};
-
-////////////////////////
-// LIFELIKE CREATIONS //
-////////////////////////
-else if( petName == "Fluxfire Feline" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Pounce" 			),	// Slot 1
-			new AandC( "Flux" 			),	// Slot 2
-			new AandC( "Prowl" 			),	// Slot 3
-			new AandC( "Supercharge" 	),	// Slot 3
-		}
-;else if(petName == "Lifelike Toad" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Water Jet" 		),	// Slot 1
-			new AandC( "Tongue Lash" 	),	// Slot 1
-			new AandC( "Healing Wave" 	),	// Slot 2
-			new AandC( "Cleansing Rain" 	),	// Slot 2
-			new AandC( "Frog Kiss" 		),	// Slot 3
-		}
-;else if(petName == "Tranquil Mechanical Yeti" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Call Lightning" 	),	// Slot 2
-			new AandC( "Call Blizzard" 	),	// Slot 2
-			new AandC( "Supercharge" 	),	// Slot 3
-			new AandC( "Ion Cannon" 		),	// Slot 3
-		}
-////////////////////////-
-// MECHANIZED CRITTERS //
-////////////////////////-
-;else if(petName == "Anodized Robo Cub" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Demolish" 		),	// Slot 1
-			new AandC( "Rebuild" 		),	// Slot 2
-			new AandC( "Maul" 			),	// Slot 3
-			new AandC( "Supercharge" 	),	// Slot 3
-		}
-;else if(petName == "Cogblade Raptor" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Overtune", () =>		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Batter" 			),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 2
-			new AandC( "Exposed Wounds" 	),	// Slot 3
-		}
-;else if(petName == "De-Weaponized Mechanical Companion" )
-	mechanical_abilities = new List<AandC>()
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Extra Plating" 	),	// Slot 2
-			new AandC( "Demolish" 		),	// Slot 3
-		}
-;else if(petName == "Mechanical Chicken" || petName == "Robo-Chick" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Batter" 			),	// Slot 1
-			new AandC( "Rebuild" 		),	// Slot 2
-			new AandC( "Supercharge" 	),	// Slot 3
-			new AandC( "Wind-Up" 		),	// Slot 3
-		}
-;else if(petName == "Mechanical Pandaren Dragonling" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Breath" 			),	// Slot 1
-			new AandC( "Thunderbolt" 	),	// Slot 1
-			new AandC( "Flyby" 			),	// Slot 2
-			new AandC( "Decoy" 			),	// Slot 2
-			new AandC( "Bombing Run" 	),	// Slot 3
-			new AandC( "Explode" 		),	// Slot 3
-		}
-;else if(petName == "Mechanical Squirrel" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Extra Plating" 	),	// Slot 2
-			new AandC( "Wind-Up" 		),	// Slot 3
-		}
-;else if(petName == "Mechanopeep" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Rebuild" 		),	// Slot 1
-			new AandC( "Batter" 			),	// Slot 2
-			new AandC( "Wind-Up" 		),	// Slot 3
-		}
-;else if(petName == "pet Bombling" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Zap" 			),	// Slot 1
-			new AandC( "Batter" 			),	// Slot 1
-			new AandC( "Minefield" 		),	// Slot 2
-			new AandC( "Toxic Smoke" 	),	// Slot 2
-			new AandC( "Screeching Gears"),	// Slot 3
-			new AandC( "Explode" 		),	// Slot 3
-		}
-;else if(petName == "Rabid Nut Varmint 5000" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Extra Plating" 	),	// Slot 2
-			new AandC( "Rabid Strike" 	),	// Slot 3
-		}
-;else if(petName == "Rocket Chicken" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Missile" 		),	// Slot 1
-			new AandC( "Peck" 			),	// Slot 1
-			new AandC( "Squawk" 			),	// Slot 2
-			new AandC( "Toxic Smoke" 	),	// Slot 2
-			new AandC( "Extra Plating" 	),	// Slot 3
-			new AandC( "Launch" 			),	// Slot 3
-		}
-////////////
-// ROBOTS //
-////////////
-;else if(petName == "Blue Clockwork Rocket Bot" || petName == "Clockwork Rocket Bot" || petName == "Lil' Smoky" || petName == "Mini Thor" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Missile" 		),	// 
-			new AandC( "Batter" 			),	// 
-			new AandC( "Toxic Smoke" 	),	// 
-			new AandC( "Minefield" 		),	// 
-			new AandC( "Sticky Grenade" 	),	// 
-			new AandC( "Launch Rocket" 	),	// 
-		}
-;else if(petName == "Clock'em" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Kick" 			),	// Slot 3
-			new AandC( "Jab" 			),	// Slot 1
-			new AandC( "Haymaker" 		),	// 
-			new AandC( "Counterstrike" 	),	// 
-			new AandC( "Dodge" 			),	// 
-		}
-;else if(petName == "Clockwork Gnome" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 2
-			new AandC( "Build Turret" 	),	// Slot 3
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Railgun" 		),	// Slot 1
-			new AandC( "Blitz" 			),	// Slot 2
-			new AandC( "Launch Rocket" 	),	// Slot 3
-		}
-;else if(petName == "Landro's Lil' XT" || petName == "Lil' XT" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 2
-			new AandC( "Zap" 			),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Heartbroken" 	),	// Slot 2
-			new AandC( "XE-321 Boombot" 	),	// Slot 3
-			new AandC( "Tympanic Tantrum" ),	// Slot 3
-		}	
-;else if(petName == "Personal World Destroyer" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 2
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Supercharge" 	),	// Slot 2
-			new AandC( "Screeching Gears" ),	// Slot 3
-			new AandC( "Quake" 			),	// Slot 3
-		}
-;else if(petName == "Son of Animus" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Metal Fist" 		),	// 
-			new AandC( "Batter" 			),	// 
-			new AandC( "Siphon Anima" 	),	// 
-			new AandC( "Touch of the Animus" ),	// 
-			new AandC( "Extra Plating" 	),	// 
-			new AandC( "Interrupting Jolt" ),	// 
-		}
-;else if(petName == "Sunreaver Micro-Sentry" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Call Lightning", ()=> !weather("Lightning Storm") 	),	// 
-			new AandC( "Extra Plating" 	),	// 
-			new AandC( "Laser" 			),	// 
-			new AandC( "Fel Immolate" 	),	// 
-			new AandC( "Haywire" 		),	// 
-			new AandC( "Supercharge" 	),	// 
-		}
-;else if(petName == "Tiny Harvester" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 3
-			new AandC( "Overtune", () => 		speed < speedEnemy && ! buff("Speed Boost") ),	// Slot 2
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Extra Plating" 	),	// Slot 2
-			new AandC( "Demolish" 		),	// Slot 3
-		}
-;else if(petName == "Warbot" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Missile" 		),	// Slot 1
-			new AandC( "Batter" 			),	// Slot 1
-			new AandC( "Toxic Smoke" 	),	// Slot 2
-			new AandC( "Minefield" 		),	// Slot 2
-			new AandC( "Extra Plating" 	),	// Slot 3
-			new AandC( "Launch Rocket" 	),	// Slot 3
-		}	
-;else if(petName == "Menagerie Custodian" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Ion Cannon", ()=>	hp < 0.35 ),	// Slot 3
-			new AandC( "Shock && Awe" 	),	// Slot 2
-			new AandC( "Zap" 			),	// Slot 1
-			new AandC( "Overtune" 		),	// Slot 1
-			new AandC( "Demolish" 		),	// Slot 2
-			new AandC( "Lock-On"			),	// Slot 3
-		}	
-;else if(petName == "Pocket Reaver" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Repair", () => 			hp < 0.7 ),	// Slot 2
-			new AandC( "Metal Fist" 		),	// Slot 1
-			new AandC( "Thrash" 			),	// Slot 1
-			new AandC( "Fel Immolate" 	),	// Slot 3
-			new AandC( "Supercharge"		),	// Slot 3
-			new AandC( "Quake" 			),	// Slot 2
-		}
-
-//////////////////-
-// MISCELLANEOUS //
-//////////////////-
-;else if(petName == "Darkmoon Tonk" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Ion Cannon",  () =>	hp < 0.35 ),	// Slot 3
-			new AandC( "Shock && Awe" 	),	// Slot 2
-			new AandC( "Minefield" 		),	// Slot 2
-			new AandC( "Missile" 		),	// Slot 1
-			new AandC( "Charge" 			),	// Slot 1
-			new AandC( "Lock-On" 		),	// Slot 3
-		}	
-;else if(petName == "Darkmoon Zeppelin" )
-	mechanical_abilities = new List<AandC>() 
-		{
-			new AandC( "Missile" 		),	// Slot 1
-			new AandC( "Thunderbolt" 	),	// Slot 1
-			new AandC( "Flyby" 			),	// Slot 2
-			new AandC( "Decoy" 			),	// Slot 2
-			new AandC( "Bombing Run" 	),	// Slot 3
-			new AandC( "Explode" 		),	// Slot 3
-		};
-            else if (petName == "Pierre")       // Studio60
-            
-                // High Fiber should only be cast if a negative aura is on our team and Heat Up is not active
-                // Should be changed, if required condition check becomes available
-                mechanical_abilities = new List<AandC>() 
-                {
-                    
-                    new AandC("Stench",     () => !debuff("Stench")), // Slot 2
-                    new AandC("Food Coma",  () => !debuff("Asleep")), // Slot 3
-                    new AandC("Heat Up"                            ), // Slot 2
-                    new AandC("High Fiber", () => !buff("Heat Up") ), // Slot 3 
-                    new AandC("Chop"     ), // Slot 1
-                    new AandC("Frying Pan") // Slot 1
-                };
-            
-
-            else if (petName == "Ancient Nest Guardian")    // Studio60
-            
-                // Feathered Frenzy is a fallback spell for elemental or aquatic enemies
-                // Entangling Roots is a fallback spell for elemental or mechanical enemies
-                mechanical_abilities = new List<AandC>() 
-                {
-                    new AandC("Feathered Frenzy", () => weak("Metal Fist") || strong("Feathered Frenzy")), // Slot 3
-                    new AandC("Extra Plating",    () => !buff("Extra Plating")), // Slot 2
-                    new AandC("Entangling Roots", () => weak("Metal Fist") || strong("Entangling Roots")), // Slot 2
-                    new AandC("Wind-Up",          () => hpEnemy > 0.5), // Slot 3
-                    new AandC("Metal Fist"), // Slot 1
-                    new AandC("Batter"    ), // Slot 1
-                };
-
-            else if (petName == "Blackfuse Bombling")    // Studio60
+            switch (petName)
             {
-                mechanical_abilities = new List<AandC>() 
-    {
-        new AandC("Bombing Run"), // Slot 2
-        new AandC("Flame Jet"), // Slot 2
-        new AandC("Explode", () => hp < 0.1), // Slot 3
-        new AandC("Armageddon", () => hp < 0.1), // Slot 3
-        new AandC("Burn"), // Slot 1
-        new AandC("Zap"), // Slot 1
-    };
+                case "Ancient Nest Guardian":
+                    /* Changelog:
+                     * 2015-01-15: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Metal Fist       | Batter
+                     * Slot 2: Extra Plating    | Entangling Roots
+                     * Slot 3: Feathered Frenzy | Wind-Up
+                     * 
+                     * Tactic Information:
+                     * Feathered Frenzy is prioritized against elemental or aquatic enemies
+                     * Entangling Roots is prioritized against elemental or aquatic enemies
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Feathered Frenzy",   () => weak("Metal Fist") || strong("Feathered Frenzy")),
+                        new AandC("Extra Plating",      () => ! buff("Extra Plating")),
+                        new AandC("Entangling Roots",   () => weak("Metal Fist") || strong("Entangling Roots")),
+                        new AandC("Wind-Up",            () => hpEnemy > 0.5),
+                        new AandC("Metal Fist"),
+                        new AandC("Batter"),
+                    };
+                    break;
+
+                case "Anodized Robo Cub":
+                    /* Abilities
+                     * Slot 1: Bite     | Demolish
+                     * Slot 2: Repair   | Rebuild
+                     * Slot 3: Maul     | Supercharge
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Bite"),
+                        new AandC("Demolish"),
+                        new AandC("Rebuild"),
+                        new AandC("Maul"),
+                        new AandC("Supercharge"),
+                    };
+                    break;
+
+                case "Blackfuse Bombling":
+                    /* Changelog:
+                     * 2015-01-20: Bombing Run is now only used if the enemy's health is above 40% (up from 0%) - Studio60
+                     * 2015-01-15: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Burn         | Zap
+                     * Slot 2: Bombing Run  | Flame Jet
+                     * Slot 3: Explode      | Armageddon
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bombing Run", () => hpEnemy > 0.4),
+                        new AandC("Flame Jet"),
+                        new AandC("Explode", () => hp < 0.1),
+                        new AandC("Armageddon", () => hp < 0.1),
+                        new AandC("Burn"),
+                        new AandC("Zap"),
+                    };
+                    break;
+
+                case "Blue Clockwork Rocket Bot":
+                case "Clockwork Rocket Bot":
+                case "Lil' Smoky":
+                case "Mini Thor":
+                    /* Abilities
+                     * Slot 1: Missile          | Batter
+                     * Slot 2: Toxic Smoke      | Minefield
+                     * Slot 3: Sticky Grenade   | Launch Rocket
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Missile"),
+                        new AandC("Batter"),
+                        new AandC("Toxic Smoke"),
+                        new AandC("Minefield"),
+                        new AandC("Sticky Grenade"),
+                        new AandC("Launch Rocket"),
+                    };
+                    break;
+
+                case "Clock'em":
+                    /* Abilities
+                     * Slot 1: Jab      | Haymaker 
+                     * Slot 2: Overtune | Counterstrike
+                     * Slot 3: Kick     | Dodge
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Kick"),
+                        new AandC("Jab"),
+                        new AandC("Haymaker"),
+                        new AandC("Counterstrike"),
+                        new AandC("Dodge"),
+                    };
+                    break;
+
+                case "Clockwork Gnome":
+                    /* Abilities
+                     * Slot 1: Metal Fist   | Railgun
+                     * Slot 2: Repair       | Blitz
+                     * Slot 3: Build Turret | Launch Turret
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Build Turret"),
+                        new AandC("Metal Fist"),
+                        new AandC("Railgun"),
+                        new AandC("Blitz"),
+                        new AandC("Launch Rocket"),
+                    };
+                    break;
+
+                case "Cogblade Raptor":
+                    /* Abilities
+                     * Slot 1: Bite             | Batter
+                     * Slot 2: Overtune         | Screech
+                     * Slot 3: Exposed Wounds   | Repair
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Bite"),
+                        new AandC("Batter"),
+                        new AandC("Screech"),
+                        new AandC("Exposed Wounds"),
+                    };
+                    break;
+
+                case "Darkmoon Tonk":
+                    /* Abilities
+                     * Slot 1: Missile          | Charge
+                     * Slot 2: Shock and Awe    | Minefield
+                     * Slot 3: Lock-On          | Ion Cannon
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ion Cannon",     () => hp < 0.35),
+                        new AandC("Shock && Awe"),
+                        new AandC("Minefield"),
+                        new AandC("Missile"),
+                        new AandC("Charge"),
+                        new AandC("Lock-On"),
+                    };
+                    break;
+
+                case "Darkmoon Zeppelin":
+                    /* Abilities
+                     * Slot 1: Missile      | Flyby
+                     * Slot 2: Bombing Run  | Explode
+                     * Slot 3: Thunderbolt  | Decoy
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Missile"),
+                        new AandC("Thunderbolt"),
+                        new AandC("Flyby"),
+                        new AandC("Decoy"),
+                        new AandC("Bombing Run"),
+                        new AandC("Explode"),
+                    };
+                    break;
+
+                case "De-Weaponized Mechanical Companion":
+                    /* Abilities
+                     * Slot 1: Metal Fist   | Thrash
+                     * Slot 2: Overtune     | Extra-Plating
+                     * Slot 3: Demolish     | Repair
+                     */
+                    mechanical_abilities = new List<AandC>()
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Extra Plating"),
+                        new AandC("Demolish"),
+                    };
+                    break;
+
+                case "Draenei Micro Defender":
+                    /* Changelog:
+                     * 2015-01-20: Shield Block is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Metal Fist           | Batter
+                     * Slot 2: Reflective Shield    | Shield Block
+                     * Slot 3: Explode              | Ion Cannon
+                     */
+                    mechanical_abilities = new List<AandC>() {
+                        new AandC("Shield Block",       () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Batter",             () => speed > speedEnemy && strong("Batter")),
+                        new AandC("Reflective Shield",  () => ! buff("Reflective Shield") || (speed < speedEnemy && buffLeft("Reflective Shield") == 1)),
+                        new AandC("Explode",            () => hpEnemy < 0.1),
+                        new AandC("Ion Cannon"),
+                        new AandC("Metal Fist"),
+                        new AandC("Batter"),
+                    };
+                    break;
+
+                case "Fluxfire Feline":
+                    /* Abilities
+                     * Slot 1: Claw     | Pounce
+                     * Slot 2: Flux     | Overtune
+                     * Slot 3: Prowl    | Supercharge
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Overtune",   () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Claw"),
+                        new AandC("Pounce"),
+                        new AandC("Flux"),
+                        new AandC("Prowl"),
+                        new AandC("Supercharge"),
+                    };
+                    break;
+
+                case "Iron Starlette":
+                    /* Abilities
+                     * Slot 1: Wind-Up      | Demolish
+                     * Slot 2: Powerball    | Toxic Smoke
+                     * Slot 3: Supercharge  | Explode
+                     * 
+                     * TODO: Explode needs to check the chances to win conventionally
+                     */
+                    mechanical_abilities = new List<AandC>() {
+                        new AandC("Explode",       () => hp < 0.1), 
+                        new AandC("Powerball",     () => speed <= speedEnemy), 
+                        new AandC("Toxic Smoke" ,  () => ! buff("Toxic Smoke")),
+                        new AandC("Wind-Up",       () => ! buff("Wind-Up")),
+                        new AandC("Supercharge",   () => shouldIHide),
+                        new AandC("Wind-Up",       () => buff("Wind-Up") && buff("Supercharge") && ! shouldIHide),
+                        new AandC("Demolish"),
+                        new AandC("Powerball"), 
+                    };
+                    break;
+
+                case "Landro's Lil' XT":
+                case "Lil' XT":
+                    /* Abilities
+                     * Slot 1: Zap              | Thrash
+                     * Slot 2: Repair           | Heartbroken
+                     * Slot 3: XE-321 Boombot   | Tympanic Tantrum
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",             () => hp < 0.7),
+                        new AandC("Zap"),
+                        new AandC("Thrash"),
+                        new AandC("Heartbroken"),
+                        new AandC("XE-321 Boombot"),
+                        new AandC("Tympanic Tantrum"),
+                    };
+                    break;
+
+                case "Lifelike Mechanical Frostboar":
+                    /* Changelog:
+                     * 2015-01-18: Rebuild is used when below 75% health (up from 50%) - Studio60
+                     * 2015-01-15: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Charge   | Missile
+                     * Slot 2: Rebuild  | Pig Out
+                     * Slot 3: Decoy    | Headbutt
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Decoy"),
+                        new AandC("Headbutt"),
+                        new AandC("Rebuild",    () => hp < 0.75),
+                        new AandC("Pig Out",    () => hp < 0.75),
+                        new AandC("Charge"),
+                        new AandC("Missile"),
+                    };
+                    break;
+
+                case "Lifelike Toad":
+                    /* Abilities
+                     * Slot 1: Water Jet    | Tongue Lash
+                     * Slot 2: Healing Wave | Cleansing Rain
+                     * Slot 3: Frog Kiss    | Repair
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Water Jet"),
+                        new AandC("Tongue Lash"),
+                        new AandC("Healing Wave"),
+                        new AandC("Cleansing Rain"),
+                        new AandC("Frog Kiss"),
+                    };
+                    break;
+
+                case "Lil' Bling":
+                    /* Changelog
+                     * 2015-01-15: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: SMCKTHAT.EXE             | Inflation
+                     * Slot 2: Blingtron Gift Package   | Extra Plating
+                     * Slot 3: Make it Rain             | Launch Rocket
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Launch Rocket",          () => buff("Setup Rocket")),
+                        new AandC("Extra Plating",          () => !buff("Extra Plating")),
+                        new AandC("Inflation",              () => debuff("Make it Rain")),
+                        new AandC("Blingtron Gift Package", () => hp < 0.75),
+                        new AandC("Make it Rain",           () => !debuff("Make it Rain")),
+                        new AandC("Launch Rocket",          () => hpEnemy > 0.25),
+                        new AandC("SMCKTHAT.EXE"),
+                        new AandC("Inflation"),
+                    };
+                    break;
+
+                case "Mechanical Chicken":
+                case "Robo-Chick":
+                    /* Abilities
+                     * Slot 1: Peck         | Batter
+                     * Slot 2: Overtune     | Rebuild
+                     * Slot 3: Supercharge  | Wind-Up
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Peck"),
+                        new AandC("Batter"),
+                        new AandC("Rebuild"),
+                        new AandC("Supercharge"),
+                        new AandC("Wind-Up"),
+                    };
+                    break;
+
+                case "Mechanical Pandaren Dragonling":
+                    /* Abilities
+                     * Slot 1: Breath       | Flyby
+                     * Slot 2: Bombing Run  | Thunderbolt
+                     * Slot 3: Explode      | Decoy
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Breath"),
+                        new AandC("Thunderbolt"),
+                        new AandC("Flyby"),
+                        new AandC("Decoy"),
+                        new AandC("Bombing Run"),
+                        new AandC("Explode"),
+                    };
+                    break;
+
+                case "Mechanical Scorpid":
+                    /* Changelog:
+                     * 2015-01-20: Puncture Wound is now checking for all poison effects - Studio60
+                     * 2015-01-19: Black Claw is only used if the enemy's health is above 15% (up from 0%) - Studio60
+                     * 2015-01-15: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Barbed Stinger   | Wind-Up
+                     * Slot 2: Blinding Poison  | Puncture Wound
+                     * Slot 3: Black Claw       | Extra Plating
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Extra Plating",      () => !buff("Extra Plating")),
+                        new AandC("Puncture Wound",     () => enemyIsPoisoned()),
+                        new AandC("Black Claw",         () => ! debuff("Black Claw") && hpEnemy > 0.15),
+                        new AandC("Blinding Poison",    () => ! debuff("Blinding Poison")),
+                        new AandC("Puncture Wound"),
+                        new AandC("Barbed Stinger"),
+                        new AandC("Wind-Up"),                     
+                    };
+                    break;
+
+                case "Mechanical Squirrel":
+                    /* Abilities
+                     * Slot 1: Metal Fist   | Trash
+                     * Slot 2: Overtune     | Extra Plating
+                     * Slot 3: Wind-Up      | Repair
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Extra Plating"),
+                        new AandC("Wind-Up"),
+                    };
+                    break;
+
+                case "Mechanopeep":
+                    /* Abilities
+                     * Slot 1: Peck     | Rebuild
+                     * Slot 2: Batter   | Overtune
+                     * Slot 3: Wind-Up  | Repair
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",     () => hp < 0.7),
+                        new AandC("Overtune",   () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Peck"),
+                        new AandC("Rebuild"),
+                        new AandC("Batter"),
+                        new AandC("Wind-Up"),
+                    };
+                    break;
+
+                case "Menagerie Custodian":
+                    /* Abilities
+                     * Slot 1: Zap              | Overtune
+                     * Slot 2: Shock and Awe    | Demolish
+                     * Slot 3: Lock-On          | Ion Cannon
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ion Cannon",     () => hp < 0.35),
+                        new AandC("Shock && Awe"),
+                        new AandC("Zap"),
+                        new AandC("Overtune"),
+                        new AandC("Demolish"),
+                        new AandC("Lock-On"),
+                    };
+                    break;
+
+                case "Personal World Destroyer":
+                    /* Abilities
+                     * Slot 1: Metal Fist       | Trash
+                     * Slot 2: Repair           | Supercharge
+                     * Slot 3: Screeching Gears | Quake
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",             () => hp < 0.7),
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Supercharge"),
+                        new AandC("Screeching Gears"),
+                        new AandC("Quake"),
+                    };
+                    break;
+
+                case "Pet Bombling":
+                    /* Abilities
+                     * Slot 1: Zap              | Batter
+                     * Slot 2: Minefield        | Toxic Smoke
+                     * Slot 3: Screeching Gears | Explode
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Zap"),
+                        new AandC("Batter"),
+                        new AandC("Minefield"),
+                        new AandC("Toxic Smoke"),
+                        new AandC("Screeching Gears"),
+                        new AandC("Explode"),
+                    };
+                    break;
+
+                case "Pierre":
+                    /* Changelog:
+                     * 2015-01-15: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Chop         | Frying Pan
+                     * Slot 2: Stench       | Heat Up
+                     * Slot 3: High Fiber   | Food Coma
+                     */
+                    // High Fiber should only be cast if a negative aura is on our team and Heat Up is not active
+                    // Should be changed, if required condition check becomes available
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Stench",     () => ! debuff("Stench")),
+                        new AandC("Food Coma",  () => ! debuff("Asleep")),
+                        new AandC("Heat Up"),
+                        new AandC("High Fiber", () => !buff("Heat Up")), 
+                        new AandC("Chop"),
+                        new AandC("Frying Pan")
+                    };
+                    break; 
+
+                case "Pocket Reaver":
+                    /* Abilities
+                     * Slot 1: Metal Fist   | Trash
+                     * Slot 2: Repair       | Quake
+                     * Slot 3: Fel Immolate | Supercharge
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Fel Immolate"),
+                        new AandC("Supercharge"),
+                        new AandC("Quake"),
+                    };
+                    break;
+
+                case "Rabid Nut Varmint 5000":
+                    /* Abilities
+                     * Slot 1: Metal Fist   | Trash
+                     * Slot 2: Overtune     | Extra Plating
+                     * Slot 3: Rabid Strike | Repair
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Extra Plating"),
+                        new AandC("Rabid Strike"),
+                    };
+                    break;
+
+
+                case "Race MiniZep":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Missile          | Flyby
+                     * Slot 2: Bombing Run      | Decoy
+                     * Slot 3: Darkmoon Curse   | Overtune
+                     */
+                    mechanical_abilities = new List<AandC>() {
+                        new AandC("Bombing Run",    () => hpEnemy > 0.5),
+                        new AandC("Decoy",          () => ! buff("Decoy")),
+                        new AandC("Darkmoon Curse", () => ! debuff("Attack Reduction")),
+                        new AandC("Overtune",       () => ! buff("Speed Boost")),
+                        new AandC("Missile"),
+                        new AandC("Flyby"),
+                    };
+                    break;
+
+                case "Rascal-Bot":
+                    /* Changelog:
+                     * 2015-01-20: Lens Flare is now checking for all blindness effects - Studio60
+                     *             Amber Prison is now checking for all stun effects - Studio60
+                     * 2015-01-19: Lens Flare is no longer used if the enemy is "Partially Blinded" (Studio60)
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Phaser       | Plot Twist
+                     * Slot 2: Lens Flare   | Amber Prison
+                     * Slot 3: Armageddon   | Reboot
+                     */
+                    mechanical_abilities = new List<AandC>()     // Studio60
+                    {    
+                        new AandC("Lens Flare",     () => ! enemyIsBlinded()),
+                        new AandC("Amber Prison",   () => ! enemyIsStunned()),                  
+                        new AandC("Armageddon",     () => hp < 0.1),
+                        new AandC("Phaser"),
+                        new AandC("Plot Twist"),              
+                        new AandC("Reboot"),
+                    };
+                    break;
+
+                case "Rocket Chicken":
+                    /* Abilities
+                     * Slot 1: Missile          | Peck
+                     * Slot 2: Squawk           | Toxic Smoke
+                     * Slot 3: Extra Plating    | Launch
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Missile"),
+                        new AandC("Peck"),
+                        new AandC("Squawk"),
+                        new AandC("Toxic Smoke"),
+                        new AandC("Extra Plating"),
+                        new AandC("Launch"),
+                    };
+                    break;
+
+                case "Sky-Bo":
+                    /* Changelog:
+                     * 2015-01-20: Launch is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Sticky Grenade is not used against enemies below 40% health - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Flamethrower     | Screeching Gears
+                     * Slot 2: Sticky Grenade   | Reboot
+                     * Slot 3: Launch           | Decoy
+                     */
+                    // launch: if we are faster, then launch should protect us from huge attacks
+                    mechanical_abilities = new List<AandC>() {
+                        new AandC("Launch",             () => shouldIHide && speed >= speedEnemy),  
+                        new AandC("Sticky Grenade",     () => ! debuff("Sticky Grenade") && hpEnemy >= 0.4),                
+                        new AandC("Decoy",              () => ! buff("Decoy")),
+                        new AandC("Flamethrower"),
+                        new AandC("Screeching Gears"),
+                        new AandC("Launch"), 
+                        new AandC("Reboot"),
+                    };
+                    break;
+
+                case "Son of Animus":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Metal Fist       | Batter
+                     * Slot 2: Siphon Anima     | Touch of the Animus
+                     * Slot 3: Extra Plating    | Interrupting Jolt
+                     */
+                    mechanical_abilities = new List<AandC>() {
+                        new AandC("Extra Plating",          () => ! buff("Extra Plating")),
+                        new AandC("Siphon Anima",           () => hp < 0.75),
+                        new AandC("Batter",                 () => speed > speedEnemy && strong("Batter")),
+                        new AandC("Touch of the Animus"),
+                        new AandC("Interrupting Jolt"),
+                        new AandC("Metal Fist"),
+                        new AandC("Batter"),
+                    };
+                    break;
+
+                case "Stonegrinder":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Changelog:
+                     * 2015-01-15: Initial tactic by Studio60
+                     * Abilities
+                     * Slot 1: Screeching Gears | Woodchipper
+                     * Slot 2: Thunderbolt      | Supercharge
+                     * Slot 3: Clean-Up         | Rebuild
+                     * 
+                     * TODO: Clean-Up needs to correctly check for battlefield objects
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {    
+                        new AandC("Clean-Up",           () => debuff("Turret") || debuff("Decoy")),
+                        new AandC("Supercharge"),    
+                        new AandC("Thunderbolt"),
+                        new AandC("Rebuild",            () => hp < 0.75),               
+                        new AandC("Screeching Gears"),
+                        new AandC("Woodchipper"),                       
+                    };
+                    break;
+
+                case "Sunblade Micro-Defender":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Zap                  | Haywire
+                     * Slot 2: Interrupting Jolt    | Repair
+                     * Slot 3: Shock and Awe        | Armageddon
+                     * 
+                     * TODO: Use Armageddon only during Failsafe (Untested)
+                     */
+                    mechanical_abilities = new List<AandC>() {
+                        new AandC("Armageddon",         () => buff("Failsafe")),
+                        new AandC("Interrupting Jolt"),
+                        new AandC("Repair",             () => hp < 0.5),
+                        new AandC("Shock and Awe"),
+                        new AandC("Zap"),
+                        new AandC("Haywire"),
+                    };
+                    break;
+
+                case "Sunreaver Micro-Sentry":
+                    /* Abilities
+                     * Slot 1: Laser            | Fel Immolate
+                     * Slot 2: Extra Plating    | Haywire
+                     * Slot 3: Call Lightning   | Supercharge
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Call Lightning", () => !weather("Lightning Storm")),
+                        new AandC("Extra Plating"),
+                        new AandC("Laser"),
+                        new AandC("Fel Immolate"),
+                        new AandC("Haywire"),
+                        new AandC("Supercharge"),
+                    };
+                    break;
+
+                case "Tiny Harvester":
+                    /* Abilities
+                     * Slot 1: Metal Fist   | Thrash
+                     * Slot 2: Overtune     | Extra Plating
+                     * Slot 3: Demolish     | Repair
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Repair",         () => hp < 0.7),
+                        new AandC("Overtune",       () => speed < speedEnemy && ! buff("Speed Boost")),
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Extra Plating"),
+                        new AandC("Demolish"),
+                    };
+                    break;
+
+                case "Tranquil Mechanical Yeti":
+                    /* Abilities
+                     * Slot 1: Metal Fist       | Thrash
+                     * Slot 2: Call Lightning   | Call Blizzard
+                     * Slot 3: Supercharge      | Ion Cannnon
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Metal Fist"),
+                        new AandC("Thrash"),
+                        new AandC("Call Lightning"),
+                        new AandC("Call Blizzard"),
+                        new AandC("Supercharge"),
+                        new AandC("Ion Cannon"),
+                    };
+                    break;
+
+                case "Warbot":
+                    /* Abilities
+                     * Slot 1: Missile          | Batter
+                     * Slot 2: Toxic Smoke      | Minefield 
+                     * Slot 3: Extra Plating    | Launch Rocket
+                     */
+                    mechanical_abilities = new List<AandC>() 
+                    {
+                        new AandC("Missile"),
+                        new AandC("Batter"),
+                        new AandC("Toxic Smoke"),
+                        new AandC("Minefield"),
+                        new AandC("Extra Plating"),
+                        new AandC("Launch Rocket"),
+                    };
+                    break;
+
+                default:
+                    ////////////////////////////
+                    // Unknown Mechanical Pet //
+                    ////////////////////////////
+                    Logger.Alert("Unknown mechanical pet: " + petName);
+                    mechanical_abilities = null;
+                    break;
             }
 
-            else if (petName == "Lifelike Mechanical Frostboar")    // Studio60
-            {
-                mechanical_abilities = new List<AandC>() 
-    {
-        new AandC("Decoy"), // Slot 3
-        new AandC("Headbutt"), // Slot 3
-        new AandC("Rebuild", () => hp < 0.5), // Slot 2
-        new AandC("Pig Out", () => hp < 0.75), // Slot 2
-        new AandC("Charge"), // Slot 1
-        new AandC("Missile"), // Slot 1
-    };
-            }
-
-            else if (petName == "Lil' Bling")    // Studio60
-            {
-                mechanical_abilities = new List<AandC>() 
-    {
-        new AandC("Launch Rocket", () => buff("Setup Rocket")), // Slot 3
-        new AandC("Extra Plating", () => !buff("Extra Plating")), // Slot 2
-        new AandC("Inflation", () => debuff("Make it Rain")), // Slot 1
-        new AandC("Blingtron Gift Package", () => hp < 0.75), // Slot 2
-        new AandC("Make it Rain", () => !debuff("Make it Rain")), // Slot 3
-        new AandC("Launch Rocket", () => hpEnemy > 0.25), // Slot 3
-        new AandC("SMCKTHAT.EXE"), // Slot 1
-        new AandC("Inflation"), // Slot 1
-    };
-            }
-
-            else if (petName == "Mechanical Scorpid")    // Studio60
-            {
-                mechanical_abilities = new List<AandC>() 
-    {
-        new AandC("Extra Plating", () => !buff("Extra Plating")), // Slot 3
-        new AandC("Puncture Wound", () => debuff("Poisoned")), // Slot 2
-        new AandC("Black Claw", () => ! debuff("Black Claw")), // Slot 3
-        new AandC("Blinding Poison", () => ! debuff("Blinding Poison") && ! shouldIHide), // Slot 2
-        new AandC("Puncture Wound"), // Slot 2
-        new AandC("Barbed Stinger"), // Slot 1
-        new AandC("Wind-Up"), // Slot 1                   
-    };
-            }
-
-            else if (petName == "Rascal-Bot")
-            {
-                mechanical_abilities = new List<AandC>()     // Studio60
-    {    
-        new AandC("Lens Flare", () => ! debuff("Blind")), // Slot 2
-        new AandC("Amber Prison", () => ! debuff("Stunned")), // Slot 2                  
-        new AandC("Armageddon", () => hp < 0.1), // Slot 3
-        new AandC("Phaser"), // Slot 1
-        new AandC("Plot Twist"), // Slot 1              
-        new AandC("Reboot"), // Slot 3
-    };
-            }
-
-            else if (petName == "Stonegrinder")    // Studio60
-            {
-                mechanical_abilities = new List<AandC>() 
-    {    
-        new AandC("Clean-Up", () => debuff("Turret") || debuff("Decoy")), // Slot 3
-        new AandC("Supercharge"), // Slot 2    
-        new AandC("Thunderbolt"), // Slot 2
-        new AandC("Rebuild", () => hp < 0.75), // Slot 3               
-        new AandC("Screeching Gears"), // Slot 1
-        new AandC("Woodchipper"), // Slot 1                       
-    };
-            }
-            
-//////////////////-
-
-            else // Unknown pet
-            {
-                Logger.Alert("Unknown mechanical pet: " + petName);
-                return null;
-            }
             return mechanical_abilities;
         }
     }

--- a/Prosto_Pets/Pets/PetTacticsBase.cs
+++ b/Prosto_Pets/Pets/PetTacticsBase.cs
@@ -87,6 +87,7 @@ namespace Prosto_Pets
         public static bool enemyIsResilient() { return MyPets.enemyIsResilient(); }
         public static bool enemyIsStunned() { return MyPets.enemyIsStunned(); }
 
+        public static bool myPetHasAbility(string ability) { return MyPets.myPetHasAbility(ability); }
         public static bool myPetIsAsleep() { return MyPets.myPetIsAsleep(); }
         public static bool myPetIsBurning() { return MyPets.myPetIsBurning(); }
         public static bool myPetIsBlinded() { return MyPets.myPetIsBlinded(); }

--- a/Prosto_Pets/Pets/Undead.cs
+++ b/Prosto_Pets/Pets/Undead.cs
@@ -24,280 +24,690 @@ namespace Prosto_Pets
 
             List<AandC> undead_abilities;
 
-//////////////////////-
-// DISEASED CRITTERS //
-//////////////////////-
-            if (petName == "Blighted Squirrel")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Scratch" 		),	// Slot 1
-			new AandC( "Woodchipper" 	),	// Slot 1
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-			new AandC( "Crouch" 			),	// Slot 2
-			new AandC( "Rabid Strike" 	),	// Slot 3
-			new AandC( "Stampede" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Blighthawk")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Cyclone", () =>			! debuff("Cyclone") ),	// Slot 3
-			new AandC( "Lift-Off" 		),	// Slot 3
-			new AandC( "Infected Claw" 	),	// Slot 1
-			new AandC( "Slicing Wind" 	),	// Slot 1
-			new AandC( "Consume Corpse" 	),	// Slot 2
-			new AandC( "Ghostly Bite" 	),	// Slot 2
-		}
-            ;
-            else if (petName == "Giant Bone Spider")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Bone Bite" 		),	// Slot 1
-			new AandC( "Poison Spit" 	),	// Slot 1
-			new AandC( "Sticky Web" 		),	// Slot 2
-			new AandC( "Siphon Life" 	),	// Slot 2
-			new AandC( "Leech Life" 		),	// Slot 3
-			new AandC( "Death Grip" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Infected Fawn")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Diseased Bite" 	),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Adrenaline Rush" ),	// Slot 2
-			new AandC( "Consume Corpse" 	),	// Slot 2
-			new AandC( "Siphon Life" 	),	// Slot 3
-			new AandC( "Death && Decay" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Infected Squirrel")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Diseased Bite" 	),	// Slot 1
-			new AandC( "Creeping Fungus" ),	// Slot 1
-			new AandC( "Rabid Strike" 	),	// Slot 2
-			new AandC( "Stampede" 		),	// Slot 2
-			new AandC( "Consume" 		),	// Slot 3
-			new AandC( "Corpse Explosion" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Infested Bear Cub")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Diseased Bite" 	),	// Slot 1
-			new AandC( "Roar" 			),	// Slot 1
-			new AandC( "Bash" 			),	// Slot 2
-			new AandC( "Hibernate" 		),	// Slot 2
-			new AandC( "Maul" 			),	// Slot 3
-			new AandC( "Corpse Explosion" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Mr. Bigglesworth")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Pounce" 			),	// Slot 1
-			new AandC( "Ice Barrier" 	),	// Slot 2
-			new AandC( "Frost Nova" 		),	// Slot 2
-			new AandC( "Ice Tomb" 		),	// Slot 3
-			new AandC( "Howling Blast" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Scourged Whelpling")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Plagued Blood",     () =>	! debuff("Plagued Blood") ),	// Slot 3
-			new AandC( "Death && Decay",    () =>   ! debuff("Death && Decay") ),	// Slot 2
-			new AandC( "Dreadful Breath",   () =>     weather("Cleansing Rain") ),	// Slot 3
-			new AandC( "Call Darkness",     () =>	! weather("Darkness") ),	// Slot 2
-			new AandC( "Shadowflame" 	),	// Slot 1
-			new AandC( "Tail Sweep" 		),	// Slot 1
-		}
-            ;
-            else if (petName == "Stitched Pup")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Diseased Bite" 	),	// Slot 1
-			new AandC( "Flurry" 			),	// Slot 1
-			new AandC( "Rabid Strike" 	),	// Slot 2
-			new AandC( "Howl" 			),	// Slot 2
-			new AandC( "Consume Corpse" 	),	// Slot 3
-			new AandC( "Plagued Blood" 	),	// Slot 3
-		}
-                    ////////////////////////-
-                    // SKELETAL COMPANIONS //
-                    ////////////////////////-
-            ;
-            else if (petName == "Fossilized Hatchling")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Ancient Blessing", () =>  ! buff("Ancient Blessing") || hp < 0.75 ),	// Slot 2
-			new AandC( "Claw" 			),	// Slot 1
-			new AandC( "Bone Bite" 		),	// Slot 1
-			new AandC( "Death && Decay"	),	// Slot 2
-			new AandC( "Bone Prison" 	),	// Slot 3
-			new AandC( "BONESTORM" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Frosty")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shriek", () =>			! debuff("Attack Reduction") ),	// Slot 2
-			new AandC( "Diseased Bite" 	),	// Slot 1
-			new AandC( "Frost Breath" 	),	// Slot 1
-			new AandC( "Call Blizzard" 	),	// Slot 2
-			new AandC( "Ice Tomb" 		),	// Slot 3
-			new AandC( "Blistering Cold" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Ghostly Skull")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Death Coil" 		),	// Slot 1
-			new AandC( "Ghostly Bite" 	),	// Slot 2
-			new AandC( "Spectral Strike"	),	// Slot 2
-			new AandC( "Siphon Life" 	),	// Slot 3
-			new AandC( "Unholy Ascension" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Landro's Lichling" || petName == "Lil' K.T.")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Howling Blast", () =>	debuff("Frost Nova") ),	// Slot 1
-			new AandC( "Siphon Life" 	),	// Slot 2
-			new AandC( "Death && Decay"	),	// Slot 2
-			new AandC( "Frost Nova" 		),	// Slot 3
-			new AandC( "Curse of Doom" 	),	// Slot 3
-		}
-                    ////////////////////-
-                    // SPECTRAL BEINGS //
-                    ////////////////////-
-            ;
-            else if (petName == "Lost of Lordaeron")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Curse of Doom", () =>	! debuff("Curse of Doom") ),	// Slot 3
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Absorb" 			),	// Slot 1
-			new AandC( "Siphon Life" 	),	// Slot 2
-			new AandC( "Arcane Explosion"),	// Slot 2
-			new AandC( "Bone Prison" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Restless Shadeling")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shadow Shock" 	),	// Slot 1
-			new AandC( "Arcane Blast" 	),	// Slot 1
-			new AandC( "Plagued Blood" 	),	// Slot 2
-			new AandC( "Death && Decay" ),	// Slot 2
-			new AandC( "Death Coil" 		),	// Slot 3
-			new AandC( "Phase Shift" 	),	// Slot 3
-		}
-            ;
-            else if (petName == "Spirit Crab")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shell Shield", 	() =>  ! buff("Shell Shield") ),	// Slot 3
-			new AandC( "Snap" 			),	// Slot 1
-			new AandC( "Amplify Magic" 	),	// Slot 1
-			new AandC( "Surge" 			),	// Slot 2
-			new AandC( "Whirlpool" 		),	// Slot 2
-			new AandC( "Dark Simulacrum" ),	// Slot 3
-		}
-                    //////////////////////-
-                    // VOODOO COMPANIONS //
-                    //////////////////////-
-            ;
-            else if (petName == "Fetish Shaman" || petName == "Sen'jin Fetish" || petName == "Voodoo Figurine")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Flame Breath" 	),	// Slot 1
-			new AandC( "Immolate" 		),	// Slot 2
-			new AandC( "Wild Magic" 		),	// Slot 2
-			new AandC( "Sear Magic" 		),	// Slot 3
-			new AandC( "Dark Simulacrum" ),	// Slot 3
-		}
-                    //////////////////-
-                    // MISCELLANEOUS //
-                    //////////////////-
-            ;
-            else if (petName == "Crawling Claw")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Curse of Doom", () =>	! debuff("Curse of Doom") ),	// Slot 3
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Agony" 			),	// Slot 1
-			new AandC( "Ancient" 		),	// Slot 2
-			new AandC( "Death Grip" 		),	// Slot 2
-			new AandC( "Dark Simulacrum" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Creepy Crate")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Devour", () => 			hpEnemy < 0.20 ),	// Slot 3,  if( we kill the enemy with Devour, we restore health
-			new AandC( "Curse of Doom", () =>	! debuff("Curse of Doom") ),	// Slot 2
-			new AandC( "Creepy Chomp" 	),	// Slot 1
-			new AandC( "Agony" 			),	// Slot 1
-			new AandC( "Death Grip" 		),	// Slot 2
-			new AandC( "BONESTORM" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Eye of the Legion")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Eyeblast" 		),	// Slot 1
-			new AandC( "Agony" 			),	// Slot 2
-			new AandC( "Gravity" 		),	// Slot 2
-			new AandC( "Soul Ward" 		),	// Slot 3
-			new AandC( "Dark Simulacrum" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Fungal Abomination")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Absorb" 			),	// Slot 1
-			new AandC( "Consume" 		),	// Slot 1
-			new AandC( "Creeping Fungus" ),	// Slot 2
-			new AandC( "Leech Seed" 		),	// Slot 2
-			new AandC( "Spore Shrooms" 	),	// Slot 3
-			new AandC( "Stun Seed" 		),	// Slot 3
-		}
-            ;
-            else if (petName == "Vampiric Batling")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Hawk Eye",	() =>	! buff("Hawk Eye") ),	// Slot 2
-			new AandC( "Bite" 			),	// Slot 1
-			new AandC( "Screech" 		),	// Slot 1
-			new AandC( "Leech Life" 		),	// Slot 2
-			new AandC( "Reckless Strike" ),	// Slot 3
-			new AandC( "Nocturnal Strike" ),	// Slot 3
-		}
-            ;
-            else if (petName == "Unborn Val'kyr")
-                undead_abilities = new List<AandC>() 
-		{
-			new AandC( "Unholy Ascension", () =>  hp < 0.3 ),	// Slot 3
-			new AandC( "Curse of Doom",    () => ! debuff("Curse of Doom") ),	// Slot 2
-			new AandC( "Shadow Slash" 	),	// Slot 1
-			new AandC( "Shadow Shock" 	),	// Slot 1
-			new AandC( "Siphon Life" 	),	// Slot 2
-			new AandC( "Haunt"			),	// Slot 3
-		};
-            //////////////////-
-            else // Unknown undead
+            switch (petName)
             {
-                Logger.Alert("Unknown undead pet: " + petName);
-                return null;
+                case "Blighted Squirrel":
+                    /* Abilities
+                     * Slot 1: Scratch          | Woodchipper
+                     * Slot 2: Adrenaline Rush  | Crouch
+                     * Slot 3: Rabid Strike     | Stampede
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Scratch"),
+                        new AandC("Woodchipper"),
+                        new AandC("Adrenaline Rush"),
+                        new AandC("Crouch"),
+                        new AandC("Rabid Strike"),
+                        new AandC("Stampede"),
+                    };
+                    break;
+
+                case "Blighthawk":
+                    /* Abilities
+                     * Slot 1: Infected Claw    | Slicing Wind
+                     * Slot 2: Consume Corpse   | Ghostly Bite
+                     * Slot 3: Lift-Off         | Cyclone
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Cyclone",        () => ! debuff("Cyclone")),
+                        new AandC("Lift-Off"),
+                        new AandC("Infected Claw"),
+                        new AandC("Slicing Wind"),
+                        new AandC("Consume Corpse"),
+                        new AandC("Ghostly Bite"),
+                    };
+                    break;
+
+                case "Crawling Claw":
+                    /* Abilities
+                     * Slot 1: Shadow Slash     | Agony
+                     * Slot 2: Ancient Blessing | Death Grip
+                     * Slot 3: Curse of Doom    | Rot
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Curse of Doom", () => ! debuff("Curse of Doom")),
+                        new AandC("Shadow Slash"),
+                        new AandC("Agony"),
+                        new AandC("Ancient"),
+                        new AandC("Death Grip"),
+                        new AandC("Dark Simulacrum"),
+                    };
+                    break;
+
+                case "Creepy Crate":
+                    /* Abilities
+                     * Slot 1: Creepy Chomp | Agony
+                     * Slot 2: Death Grip   | Curse of Doom
+                     * Slot 3: Devour       | BONESTORM
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Devour",         () => hpEnemy < 0.20 ),
+                        new AandC("Curse of Doom",  () => ! debuff("Curse of Doom")),
+                        new AandC("Creepy Chomp"),
+                        new AandC("Agony"),
+                        new AandC("Death Grip"),
+                        new AandC("BONESTORM"),
+                    };
+                    break;
+
+                case "Cursed Birman":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Pounce           | Spirit Claws
+                     * Slot 2: Call Darkness    | Spirit Spikes
+                     * Slot 3: Devour           | Prowl
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Devour",         () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Call Darkness",  () => ! weather("Darkness")),
+                        new AandC("Spirit Spikes"),
+                        new AandC("Prowl"),
+                        new AandC("Pounce"),
+                        new AandC("Spirit Claws"),
+                    };
+                    break;
+
+                case "Eye of the Legion":
+                    /* Abilities
+                     * Slot 1: Shadow Slash | Eyeblast
+                     * Slot 2: Agony        | Gravity
+                     * Slot 3: Soul Ward    | Rot
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shadow Slash"),
+                        new AandC("Eyeblast"),
+                        new AandC("Agony"),
+                        new AandC("Gravity"),
+                        new AandC("Soul Ward"),
+                        new AandC("Dark Simulacrum"),
+                    };
+                    break;
+
+                case "Fetish Shaman":
+                case "Sen'jin Fetish":
+                case "Voodoo Figurine":
+                    /* Abilities
+                     * Slot 1: Shadow Slash | Flame Breath
+                     * Slot 2: Immolate     | Wild Magic
+                     * Slot 3: Sear Magic   | Rot
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shadow Slash"),
+                        new AandC("Flame Breath"),
+                        new AandC("Immolate"),
+                        new AandC("Wild Magic"),
+                        new AandC("Sear Magic"),
+                        new AandC("Dark Simulacrum"),
+                    };
+                    break;
+
+                case "Fossilized Hatchling":
+                    /* Abilities
+                     * Slot 1: Claw             | Bone Bite
+                     * Slot 2: Ancient Blessing | Death and Decay
+                     * Slot 3: Bone Prison      | BONESTORM
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Ancient Blessing", () => ! buff("Ancient Blessing") || hp < 0.75 ),
+                        new AandC("Claw"),
+                        new AandC("Bone Bite"),
+                        new AandC("Death && Decay"),
+                        new AandC("Bone Prison"),
+                        new AandC("BONESTORM"),
+                    };
+                    break;
+
+                case "Fragment of Anger":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     *  Abilities
+                     * Slot 1: Spiritfire Bolt  | Seethe
+                     * Slot 2: Spiritfire Beam  | Enrage
+                     * Slot 3: Soulrush         | Spirit Spikes
+                     * 
+                     * TODO: Spiritfire Beam needs to check the state of the enemy team
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Enrage",             () => ! buff("Enrage")),
+                        new AandC("Soulrush"),
+                        new AandC("Spirit Spikes"),
+                        new AandC("Spiritfire Bolt"),
+                        new AandC("Seethe"),
+                        new AandC("Spiritfire Beam"),
+                    };
+                    break;
+
+                case "Fragment of Desire":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Spiritfire Bolt      | Arcane Blast
+                     * Slot 2: Reflective Shield    | Soul Ward
+                     * Slot 3: Soulrush             | Soothe
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Soul Ward",          () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Reflective Shield",  () => ! buff("Reflective Shield")),
+                        new AandC("Soulrush"),
+                        new AandC("Spiritfire Bolt"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Soothe"),
+                    };
+                    break;
+
+                case "Fragment of Suffering":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Arcane Blast | Spiritfire Bolt
+                     * Slot 2: Darkflame    | Breath of Sorrow
+                     * Slot 3: Drain Power  | Soulrush
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Drain Power",        () => ! debuff("Attack Reduction")),
+                        new AandC("Darkflame",          () => ! debuff("Healing Reduction")),
+                        new AandC("Breath of Sorrow",   () => ! debuff("Healing Reduction")),
+                        new AandC("Soulrush"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Spiritfire Bolt"),
+                    };
+                    break;
+
+                case "Frostwolf Ghostpup":
+                    /* Changelog:
+                     * 2015-01-20: Frolicking is now used more regularly - Studio60
+                     *             Refuge is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Scratch  | Sneak Attack
+                     * Slot 2: Refuge   | Haunting Song
+                     * Slot 3: Frolick  | Ghostly Bite
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Refuge",         () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Haunting Song",  () => hp < 0.8),
+                        new AandC("Frolick",        () => ! buff("Frolicking")),
+                        new AandC("Ghostly Bite"),
+                        new AandC("Scratch"),
+                        new AandC("Sneak Attack"),
+                    };
+                    break;
+
+                case "Frosty":
+                    /* Abilities
+                     * Slot 1: Diseased Bite    | Frost Breath
+                     * Slot 2: Call Blizzard    | Shriek
+                     * Slot 3: Ice Tomb         | Blistering Cold
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shriek",             () => ! debuff("Attack Reduction")),
+                        new AandC("Diseased Bite"),
+                        new AandC("Frost Breath"),
+                        new AandC("Call Blizzard"),
+                        new AandC("Ice Tomb"),
+                        new AandC("Blistering Cold"),
+                    };
+                    break;
+
+                case "Fungal Abomination":
+                    /* Abilities
+                     * Slot 1: Absorb           | Consume
+                     * Slot 2: Creeping Fungus  | Leech Seed
+                     * Slot 3: Spore Shrooms    | Stun Seed
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Absorb"),
+                        new AandC("Consume"),
+                        new AandC("Creeping Fungus"),
+                        new AandC("Leech Seed"),
+                        new AandC("Spore Shrooms"),
+                        new AandC("Stun Seed"),
+                    };
+                    break;
+
+                case "Ghastly Kid":
+                    /* Changelog:
+                     * 2015-01-20: Ghostly Bite is now longer used if pet health is below 40% (up from 0%) - Studio60
+                     * 2015-01-19: Consume Magic is now used when below 60% health (changed from 0%) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Hoof             | Diseased Bite
+                     * Slot 2: Consume Magic    | Ethereal
+                     * Slot 3: Ghostly Bite     | Haunt
+                     * 
+                     * TODO: Consume Magic needs to consider buffs/debuffs
+                     * TODO: Haunt needs to check if other pets are available
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Ethereal",       () => shouldIHide),
+                        new AandC("Consume Magic",  () => hp < 0.6),
+                        new AandC("Ghostly Bite",   () => hp < 0.4),
+                        new AandC("Hoof"),
+                        new AandC("Diseased Bite"),
+                        new AandC("Haunt"),
+                    };
+                    break;
+
+                case "Ghostly Skull":
+                    /* Abilities
+                     * Slot 1: Shadow Slash | Death Coil
+                     * Slot 2: Ghostly Bite | Spectral Strike
+                     * Slot 3: Siphon Life  | Unholy Ascension
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shadow Slash"),
+                        new AandC("Death Coil"),
+                        new AandC("Ghostly Bite"),
+                        new AandC("Spectral Strike"),
+                        new AandC("Siphon Life"),
+                        new AandC("Unholy Ascension"),
+                    };
+                    break;
+
+                case "Giant Bone Spider":
+                    /* Abilities
+                     * Slot 1: Bone Bite    | Poison Spit
+                     * Slot 2: Sticky Web   | Siphon Life
+                     * Slot 3: Leech Life   | Death Grip
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Bone Bite"),
+                        new AandC("Poison Spit"),
+                        new AandC("Sticky Web"),
+                        new AandC("Siphon Life"),
+                        new AandC("Leech Life"),
+                        new AandC("Death Grip"),
+                    };
+                    break;
+
+                case "Grotesque":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Gargoyle Strike  | Shadow Shock
+                     * Slot 2: Ravage           | Agony
+                     * Slot 3: Stone Form       | Ghostly Bite
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Ravage",             () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Agony",              () => ! debuff("Agony")),
+                        new AandC("Stone Form",         () => hp < 0.4),
+                        new AandC("Ghostly Bite"),
+                        new AandC("Gargoyle Strike"),
+                        new AandC("Shadow Shock"),
+                    };
+                    break;
+
+                case "Infected Fawn":
+                    /* Abilities
+                     * Slot 1: Diseased Bite    | Flurry
+                     * Slot 2: Adrenaline Rush  | Consume Corpse
+                     * Slot 3: Siphon Life      | Death and Decay
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Diseased Bite"),
+                        new AandC("Flurry"),
+                        new AandC("Adrenaline Rush"),
+                        new AandC("Consume Corpse"),
+                        new AandC("Siphon Life"),
+                        new AandC("Death && Decay"),
+                    };
+                    break;
+
+                case "Infected Squirrel":
+                    /* Abilities
+                     * Slot 1: Diseased Bite    | Stampede
+                     * Slot 2: Rabid Strike     | Creeping Fungus
+                     * Slot 3: Consume          | Corpse Explosion
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Diseased Bite"),
+                        new AandC("Creeping Fungus"),
+                        new AandC("Rabid Strike"),
+                        new AandC("Stampede"),
+                        new AandC("Consume"),
+                        new AandC("Corpse Explosion"),
+                    };
+                    break;
+
+                case "Infested Bear Cub":
+                    /* Abilities
+                     * Slot 1: Diseased Bite    | Roar
+                     * Slot 2: Bash             | Hibernate
+                     * Slot 3: Maul             | Corpse Explosion
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Diseased Bite"),
+                        new AandC("Roar"),
+                        new AandC("Bash"),
+                        new AandC("Hibernate"),
+                        new AandC("Maul"),
+                        new AandC("Corpse Explosion"),
+                    };
+                    break;
+
+                case "Landro's Lichling":
+                case "Lil' K.T.":
+                    /* Abilities
+                     * Slot 1: Shadow Slash | Howling Blast
+                     * Slot 2: Siphon Life  | Death and Decay
+                     * Slot 3: Frost Nova   | Curse of Doom
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shadow Slash"),
+                        new AandC("Howling Blast",  () => debuff("Frost Nova")),
+                        new AandC("Siphon Life"),
+                        new AandC("Death && Decay"),
+                        new AandC("Frost Nova"),
+                        new AandC("Curse of Doom"),
+                    };
+                    break;
+
+                case "Lost of Lordaeron":
+                    /* Abilities
+                     * Slot 1: Shadow Slash | Absorb
+                     * Slot 2: Siphon Life  | Arcane Explosion
+                     * Slot 3: Bone Prison  | Curse of Doom
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Curse of Doom",      () => ! debuff("Curse of Doom")),
+                        new AandC("Shadow Slash"),
+                        new AandC("Absorb"),
+                        new AandC("Siphon Life"),
+                        new AandC("Arcane Explosion"),
+                        new AandC("Bone Prison"),
+                    };
+                    break;
+
+                case "Macabre Marionette":
+                    /* Changelog:
+                     * 2015-01-20: Siphon Life is no longer health dependent and is cast if it is not already active - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Macabre Maraca   | Bone Bite
+                     * Slot 2: Death and Decay  | Siphon Life
+                     * Slot 3: Dead Man's Party | Bone Barrage
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Death and Decay",    () => ! debuff("Death and Decay")),
+                        new AandC("Siphon Life",        () => ! debuff("Siphon Life")),
+                        new AandC("Dead Man's Party",   () => ! debuff("Shattered Defenses")),
+                        new AandC("Bone Barrage",       () => ! debuff("Bone Barrage")),
+                        new AandC("Macabre Maraca"),
+                        new AandC("Bone Bite"),
+                    };
+                    break;
+
+                case "Mr. Bigglesworth":
+                    /* Abilities
+                     * Slot 1: Claw         | Pounce
+                     * Slot 2: Ice Barrier  | Frost Nova
+                     * Slot 3: Ice Tomb     | Howling Blast
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Claw"),
+                        new AandC("Pounce"),
+                        new AandC("Ice Barrier"),
+                        new AandC("Frost Nova"),
+                        new AandC("Ice Tomb"),
+                        new AandC("Howling Blast"),
+                    };
+                    break;
+
+                case "Restless Shadeling":
+                    /* Abilities
+                     * Slot 1: Shadow Shock     | Arcane Blast
+                     * Slot 2: Plagued Blood    | Death and Decay
+                     * Slot 3: Death Coil       | Phase Shift
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shadow Shock"),
+                        new AandC("Arcane Blast"),
+                        new AandC("Plagued Blood"),
+                        new AandC("Death && Decay"),
+                        new AandC("Death Coil"),
+                        new AandC("Phase Shift"),
+                    };
+                    break;
+
+                case "Scourged Whelpling":
+                    /* Abilities
+                     * Slot 1: Shadowflame      | Tail Sweep
+                     * Slot 2: Call Darkness    | Death and Decay
+                     * Slot 3: Plagued Blood    | Dreadful Breath
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Plagued Blood",     () => ! debuff("Plagued Blood")),
+                        new AandC("Death && Decay",    () => ! debuff("Death && Decay")),
+                        new AandC("Dreadful Breath",   () => weather("Cleansing Rain")),
+                        new AandC("Call Darkness",     () => ! weather("Darkness")),
+                        new AandC("Shadowflame"),
+                        new AandC("Tail Sweep"),
+                    };
+                    break;
+
+                case "Son of Sethe":
+                    /* Changelog:
+                     * 2015-01-20: Hiss is now used with a higher priority - Studio60
+                     *             Lift-Off is now also used to hide from huge attacks if both pets have equal speed - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Absorb       | Plagued Blood
+                     * Slot 2: Hiss         | Touch of the Animus
+                     * Slot 3: Drain Blood  | Lift-Off
+                     * 
+                     * Tactic Information:
+                     * Hiss is only worth using if it makes us faster than the enemy
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Lift-Off",               () => shouldIHide && speed >= speedEnemy),
+                        new AandC("Plagued Blood",          () => ! debuff("Plagued")),
+                        new AandC("Hiss",                   () => (speed <= speedEnemy && ! debuff("Speed Reduction")) || strong("Hiss")),
+                        new AandC("Touch of the Animus",    () => ! debuff("Plagued")),
+                        new AandC("Drain Blood",            () => hp < 0.6),
+                        new AandC("Lift-Off"),
+                        new AandC("Hiss",                   () => ! debuff("Speed Reduction") && ! weak("Hiss")),
+                        new AandC("Absorb"),
+                        new AandC("Plagued Blood"),
+                    };
+                    break;
+
+                case "Spirit Crab":
+                    /* Abilities
+                     * Slot 1: Snap         | Amplify Magic
+                     * Slot 2: Surge        | Whirlpool
+                     * Slot 3: Shell Shield | Rot
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Shell Shield",       () => ! buff("Shell Shield")),
+                        new AandC("Snap"),
+                        new AandC("Amplify Magic"),
+                        new AandC("Surge"),
+                        new AandC("Whirlpool"),
+                        new AandC("Dark Simulacrum"),
+                    };
+                    break;
+
+                case "Stitched Pup":
+                    /* Abilities
+                     * Slot 1: Diseased Bite    | Flurry
+                     * Slot 2: Rabid Strike     | Howl
+                     * Slot 3: Consume Corpse   | Plagued Blood
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Diseased Bite"),
+                        new AandC("Flurry"),
+                        new AandC("Rabid Strike"),
+                        new AandC("Howl"),
+                        new AandC("Consume Corpse"),
+                        new AandC("Plagued Blood"),
+                    };
+                    break;
+
+                case "Stinkrot":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60 for new pet coming in patch 6.1
+                     * 
+                     * Abilities
+                     * Slot 1: Diseased Bite    | Infected Claw
+                     * Slot 2: Rot              | Plagued Blood
+                     * Slot 3: Corpse Explosion | Digest Brains
+                     * 
+                     * Tactic Information:
+                     * Rot should not be used against humans
+                     * 
+                     * TODO: Corpse Explosion needs to detect own team status
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Rot",            () => ! debuff("Rot") && ! famEnemy(PF.Humanoid)),
+                        new AandC("Plagued Blood",  () => ! debuff("Plagued")),
+                        new AandC("Digest Brains",  () => hp < 0.6),
+                        new AandC("Diseased Bite"),
+                        new AandC("Infected Claw"),
+                        new AandC("Corpse Explosion"),
+                    };
+                    break;
+
+                case "Unborn Val'kyr":
+                    /* Abilities
+                     * Slot 1: Shadow Slash | Shadow Stock
+                     * Slot 2: Siphon Life  | Curse of Doom
+                     * Slot 3: Haunt        | Unholy Ascension
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Unholy Ascension", () => hp < 0.3 ),
+                        new AandC("Curse of Doom",    () => ! debuff("Curse of Doom")),
+                        new AandC("Shadow Slash"),
+                        new AandC("Shadow Shock"),
+                        new AandC("Siphon Life"),
+                        new AandC("Haunt"),
+                    };
+                    break;
+
+                case "Vampiric Batling":
+                    /* Abilities
+                     * Slot 1: Bite             | Screech
+                     * Slot 2: Leech Life       | Hawk Eye
+                     * Slot 3: Reckless Strike  | Nocturnal Strike
+                     */
+                    undead_abilities = new List<AandC>() 
+                    {
+                        new AandC("Hawk Eye",           () => ! buff("Hawk Eye")),
+                        new AandC("Bite"),
+                        new AandC("Screech"),
+                        new AandC("Leech Life"),
+                        new AandC("Reckless Strike"),
+                        new AandC("Nocturnal Strike"),
+                    };
+                    break;
+
+                case "Weebomination":
+                    /* Changelog:
+                     * 2015-01-20: Corpse Explosion - Fixed an ability typo (thanks to Valpsjuk) - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Cleave           | Diseased Bite
+                     * Slot 2: Consume Corpse   | Death Grip
+                     * Slot 3: Corpse Explosion | Haymaker
+                     * 
+                     * TODO: Consume Corpse needs to check own team status
+                     * TODO: Death Grip needs to check own team status
+                     * TODO: Corpse Explosion needs to check own team status
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Haymaker",           () => strong("Haymaker")),
+                        new AandC("Cleave"),
+                        new AandC("Diseased Bite"),
+                        new AandC("Consume Corpse"),
+                        new AandC("Death Grip"),
+                        new AandC("Corpse Explosion"),
+                    };
+                    break;
+
+                case "Widget the Departed":
+                    /* Changelog:
+                     * 2015-01-20: Spectral Strike is now checking for all blindness effects - Studio60
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Pounce           | Spirit Clawss
+                     * Slot 2: Devour           | Spectral Strike
+                     * Slot 3: Call Darkness    | Prowl
+                     */
+                    // prowl: trying to only use it, if we stay faster after using it
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Devour",             () => hpEnemy < 0.25 || (famEnemy(PF.Critter) && hpEnemy > 0.4)),
+                        new AandC("Spectral Strike",    () => enemyIsBlinded()),
+                        new AandC("Call Darkness",      () => ! weather("Darkness")),
+                        new AandC("Prowl",              () => speed * 0.7 > speedEnemy),
+                        new AandC("Pounce"),
+                        new AandC("Spirit Claws"),
+                    };
+                    break;
+
+                case "Zomstrok":
+                    /* Changelog:
+                     * 2015-01-18: Initial tactic by Studio60
+                     * 
+                     * Abilities
+                     * Slot 1: Infected Claw    | Creeping Fungus
+                     * Slot 2: Shell Shield     | Rot
+                     * Slot 3: Carpnado         | Toxic Skin
+                     */
+                    undead_abilities = new List<AandC>() {
+                        new AandC("Shell Shield",       () => ! buff("Shell Shield")),
+                        new AandC("Rot",                () => ! debuff("Rot")),
+                        new AandC("Carpnado"),
+                        new AandC("Toxic Skin",         () => ! buff("Toxic Skin")),
+                        new AandC("Infected Claw"),
+                        new AandC("Creeping Fungus"),
+                    };
+                    break;
+
+                default:
+                    ////////////////////////
+                    // Unknown Undead Pet //
+                    ////////////////////////
+                    Logger.Alert("Unknown undead pet: " + petName);
+                    undead_abilities = null;
+                    break;
             }
+
             return undead_abilities;
+
         }
     }
 }


### PR DESCRIPTION
All new 120+ custom pet tactics have been added to the type specific core tactics. Code has also been cleaned up quite a bit. This seems to be a strong base for upcoming tactic improvements.

Example tactic in the custom.cs had to be commented out. Otherwise it would always override core tactics.
